### PR TITLE
Remove findBySlug method to use the query builder

### DIFF
--- a/src/Jobs/ImportCollectionsForProductJob.php
+++ b/src/Jobs/ImportCollectionsForProductJob.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Statamic\Facades\Term;
+use function config;
 
 class ImportCollectionsForProductJob implements ShouldQueue
 {
@@ -30,7 +31,10 @@ class ImportCollectionsForProductJob implements ShouldQueue
         $product_collections = collect();
 
         foreach ($this->collections as $collection) {
-            $term = Term::findBySlug($collection['handle'], config('shopify.taxonomies.collections'));
+            $term = Term::query()
+                ->where('slug', $collection['handle'])
+                ->where('taxonomy', config('shopify.taxonomies.collections'))
+                ->first();
 
             if (!$term) {
                 $term = Term::make()


### PR DESCRIPTION
The findBySlug method on the TermRepository has been deprecated for a while now and has completely been removed from Statamic 4. So rewrote it to use the query builder. This together with #144 Should make this working in statamic 4.

See https://github.com/statamic/cms/pull/3671 and https://github.com/statamic/cms/pull/7536