### PR TITLE
Don't clear cache after import

### DIFF
--- a/src/Jobs/ImportAllProductsJob.php
+++ b/src/Jobs/ImportAllProductsJob.php
@@ -28,7 +28,5 @@ class ImportAllProductsJob implements ShouldQueue
         foreach ($this->data as $product) {
             ImportSingleProductJob::dispatch($product)->onQueue(config('shopify.queue'));
         }
-
-        Artisan::call('cache:clear');
     }
 }


### PR DESCRIPTION
Theres no reason (that I can see) to clear the cache after import

Fixes #142 