### PR TITLE
Create `deploy demo store` workflow

### DIFF
--- a/.github/workflows/demo-store.yml
+++ b/.github/workflows/demo-store.yml
@@ -1,0 +1,40 @@
+name: Deploy demo store
+on:
+  release:
+  workflow_dispatch:
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DEMO_STORE_PROJECT_ID }}
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    steps:
+     # Check out master branch
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          repository: 'statamic-rad-pack/shopify-demo'
+
+      # Downloads, configures and caches Node.js
+      - name: Setup node env
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      # Install all dependencies needed to build our documentation
+      - name: Install dependencies
+        run: yarn
+
+      # Pull vercel project info
+      - name: Vercel pull
+        run: yarn vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      # Build for vercel output
+      - name: Vercel build
+        run: yarn vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      # Deploy to vercel
+      - name: Vercel deploy
+        run: yarn vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 A Statamic 3 addon that allows you to integrate Shopify. World-class ecommerce mixed with the brilliance of Statamic.
 
-[Live Demo](https://shopify.jackwhiting.dev) -
+[Live Demo](https://statamic-shopify-demostore.vercel.app) -
 [Docs](https://statamic-shopify-docs.vercel.app)
 <!-- /statamic:hide -->
 

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,6 @@
             "role": "Developer"
         }
     ],
-    "support": {
-        "email": "hi@jackwhiting.co.uk"
-    },
     "require": {
         "phpclassic/php-shopify": "^1.1",
         "pixelfear/composer-dist-plugin": "^0.1",


### PR DESCRIPTION
Not 100% sure this will work without a GitHub token as the demo store is a private repo (we could change that).
But its a start at least.