### PR TITLE
Fire events on webhook receive to allow for additional logic to be performed

### DIFF
--- a/docs/content/en/CMS/webhooks.md
+++ b/docs/content/en/CMS/webhooks.md
@@ -66,10 +66,10 @@ Each webhook listener also fires an event you can use to hook into with your own
 
 The available events are:
 
-`StatamicRadPack\Events\ProductCreate`
-`StatamicRadPack\Events\ProductDelete`
-`StatamicRadPack\Events\ProductUpdate`
-`StatamicRadPack\Events\OrderCreate`
+`StatamicRadPack\Shopify\Events\ProductCreate`
+`StatamicRadPack\Shopify\Events\ProductDelete`
+`StatamicRadPack\Shopify\Events\ProductUpdate`
+`StatamicRadPack\Shopify\Events\OrderCreate`
 
 Each event has one property `$data` with the payload data decoded to a `stdClass`.
 

--- a/docs/content/en/CMS/webhooks.md
+++ b/docs/content/en/CMS/webhooks.md
@@ -71,5 +71,5 @@ The available events are:
 `StatamicRadPack\Events\ProductUpdate`
 `StatamicRadPack\Events\OrderCreate`
 
-Each event has one property `$data` with the payload data decoded to an array.
+Each event has one property `$data` with the payload data decoded to a `stdClass`.
 

--- a/docs/content/en/CMS/webhooks.md
+++ b/docs/content/en/CMS/webhooks.md
@@ -59,3 +59,17 @@ Your URL should point to the following endpoint:
 ```bash
 https://YOURSITE/!/shopify/webhook/order
 ```
+
+## Events
+
+Each webhook listener also fires an event you can use to hook into with your own logic based on the payload received.
+
+The available events are:
+
+`StatamicRadPack\Events\ProductCreate`
+`StatamicRadPack\Events\ProductDelete`
+`StatamicRadPack\Events\ProductUpdate`
+`StatamicRadPack\Events\OrderCreate`
+
+Each event has one property `$data` with the payload data decoded to an array.
+

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -12,11 +12,11 @@ Route::name('shopify.')->group(function () {
         ->withoutMiddleware([VerifyCsrfToken::class])
         ->name('webhook.order.created');
 
-    Route::post('/webhook/product/create', ProductCreateUpdateController::class)
+    Route::post('/webhook/product/create', [ProductCreateUpdateController::class, 'create'])
         ->withoutMiddleware([VerifyCsrfToken::class])
         ->name('webhook.product.create');
 
-    Route::post('/webhook/product/update', ProductCreateUpdateController::class)
+    Route::post('/webhook/product/update', [ProductCreateUpdateController::class, 'update'])
         ->withoutMiddleware([VerifyCsrfToken::class])
         ->name('webhook.product.update');
 

--- a/src/Events/OrderCreate.php
+++ b/src/Events/OrderCreate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class OrderCreate
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public array $data)
+    {
+    }
+}

--- a/src/Events/OrderCreate.php
+++ b/src/Events/OrderCreate.php
@@ -4,12 +4,13 @@ namespace StatamicRadPack\Shopify\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use stdClass;
 
 class OrderCreate
 {
     use Dispatchable, SerializesModels;
 
-    public function __construct(public array $data)
+    public function __construct(public stdClass $data)
     {
     }
 }

--- a/src/Events/ProductCreate.php
+++ b/src/Events/ProductCreate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductCreate
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public array $data)
+    {
+    }
+}

--- a/src/Events/ProductCreate.php
+++ b/src/Events/ProductCreate.php
@@ -4,12 +4,13 @@ namespace StatamicRadPack\Shopify\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use stdClass;
 
 class ProductCreate
 {
     use Dispatchable, SerializesModels;
 
-    public function __construct(public array $data)
+    public function __construct(public stdClass $data)
     {
     }
 }

--- a/src/Events/ProductDelete.php
+++ b/src/Events/ProductDelete.php
@@ -4,12 +4,13 @@ namespace StatamicRadPack\Shopify\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use stdClass;
 
 class ProductDelete
 {
     use Dispatchable, SerializesModels;
 
-    public function __construct(public array $data)
+    public function __construct(public stdClass $data)
     {
     }
 }

--- a/src/Events/ProductDelete.php
+++ b/src/Events/ProductDelete.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductDelete
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public array $data)
+    {
+    }
+}

--- a/src/Events/ProductUpdate.php
+++ b/src/Events/ProductUpdate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductUpdate
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(public array $data)
+    {
+    }
+}

--- a/src/Events/ProductUpdate.php
+++ b/src/Events/ProductUpdate.php
@@ -4,12 +4,13 @@ namespace StatamicRadPack\Shopify\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use stdClass;
 
 class ProductUpdate
 {
     use Dispatchable, SerializesModels;
 
-    public function __construct(public array $data)
+    public function __construct(public stdClass $data)
     {
     }
 }

--- a/src/Http/Controllers/Webhooks/OrderCreateController.php
+++ b/src/Http/Controllers/Webhooks/OrderCreateController.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Shopify\Http\Controllers\Webhooks;
 
 use Illuminate\Http\Request;
 use PHPShopify\ShopifySDK;
+use StatamicRadPack\Shopify\Events;
 use StatamicRadPack\Shopify\Jobs\ImportSingleProductJob;
 
 class OrderCreateController extends WebhooksController
@@ -28,6 +29,8 @@ class OrderCreateController extends WebhooksController
             $product = $shopify->Product($item->product_id)->get();
             ImportSingleProductJob::dispatch($product)->onQueue(config('shopify.queue'));
         }
+
+        Events\OrderCreate::dispatch($data);
 
         return response()->json([], 200);
     }

--- a/src/Http/Controllers/Webhooks/ProductCreateUpdateController.php
+++ b/src/Http/Controllers/Webhooks/ProductCreateUpdateController.php
@@ -11,12 +11,12 @@ class ProductCreateUpdateController extends WebhooksController
 {
     public function create(Request $request)
     {
-        $this->processWebhook($request, fn($data) => Events\ProductCreate::dispatch($data));
+        return $this->processWebhook($request, fn($data) => Events\ProductCreate::dispatch($data));
     }
 
     public function update(Request $request)
     {
-        $this->processWebhook($request, fn($data) => Events\ProductUpdate::dispatch($data));
+        return $this->processWebhook($request, fn($data) => Events\ProductUpdate::dispatch($data));
     }
 
     private function processWebhook(Request $request, Closure $eventCallback)
@@ -30,10 +30,11 @@ class ProductCreateUpdateController extends WebhooksController
         }
 
         // Decode data
-        $data = json_decode($data, true);
+        $dataArray = json_decode($data, true);
+        $data = json_decode($data);
 
         // Dispatch job
-        ImportSingleProductJob::dispatch($data)->onQueue(config('shopify.queue'));
+        ImportSingleProductJob::dispatch($dataArray)->onQueue(config('shopify.queue'));
 
         $eventCallback($data);
 

--- a/src/Http/Controllers/Webhooks/ProductDeleteController.php
+++ b/src/Http/Controllers/Webhooks/ProductDeleteController.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Shopify\Http\Controllers\Webhooks;
 
 use Illuminate\Http\Request;
 use Statamic\Facades\Entry;
+use StatamicRadPack\Shopify\Events;
 
 class ProductDeleteController extends WebhooksController
 {
@@ -23,6 +24,8 @@ class ProductDeleteController extends WebhooksController
         if (! is_object($data) && ! $data->id) {
             return;
         }
+
+        Events\ProductDelete::dispatch($data)
 
         $productEntry = Entry::query()
             ->where('collection', 'products')

--- a/src/Http/Controllers/Webhooks/ProductDeleteController.php
+++ b/src/Http/Controllers/Webhooks/ProductDeleteController.php
@@ -25,7 +25,7 @@ class ProductDeleteController extends WebhooksController
             return;
         }
 
-        Events\ProductDelete::dispatch($data)
+        Events\ProductDelete::dispatch($data);
 
         $productEntry = Entry::query()
             ->where('collection', 'products')


### PR DESCRIPTION
This PR adds events fired from the webhook controllers to allow developers to add their own processes that listen for these webhooks (eg clearing caches, updating other data sources).