### PR TITLE
site.js fixes - they arent classes, so dont use `new`.

### DIFF
--- a/resources/js/front.js
+++ b/resources/js/front.js
@@ -2,7 +2,7 @@ import checkout from './shopify/checkout'
 import cart, { setCartCount } from './shopify/cart'
 import productForm from './shopify/products'
 
-new checkout()
-new setCartCount()
-new productForm()
-new cart()
+checkout()
+setCartCount()
+productForm()
+cart()


### PR DESCRIPTION
Webpack must be more forgiving than vite

Fixes: https://github.com/statamic-rad-pack/shopify/issues/140