### PR TITLE
Customise nav to bring it all under a `Shopify` section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "phpclassic/php-shopify": "^1.1",
         "pixelfear/composer-dist-plugin": "^0.1",
-        "statamic/cms": "^4.0"
+        "statamic/cms": "^4.22"
     },
     "require-dev": {
         "jasonmccreary/laravel-test-assertions": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "phpclassic/php-shopify": "^1.1",
         "pixelfear/composer-dist-plugin": "^0.1",
-        "statamic/cms": "^4.22"
+        "statamic/cms": "^4.0"
     },
     "require-dev": {
         "jasonmccreary/laravel-test-assertions": "^2.0",

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use PHPShopify\ShopifySDK;
 use Statamic\Facades\Collection;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
+use Statamic\Facades\Taxonomy;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -97,23 +98,62 @@ class ServiceProvider extends AddonServiceProvider
         $shopifySvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 109.5 124.5"><path d="M74.7 14.8s-1.4.4-3.7 1.1c-.4-1.3-1-2.8-1.8-4.4-2.6-5-6.5-7.7-11.1-7.7-.3 0-.6 0-1 .1-.1-.2-.3-.3-.4-.5-2-2.2-4.6-3.2-7.7-3.1-6 .2-12 4.5-16.8 12.2-3.4 5.4-6 12.2-6.7 17.5-6.9 2.1-11.7 3.6-11.8 3.7-3.5 1.1-3.6 1.2-4 4.5-.6 2.5-9.7 73-9.7 73l75.6 13.1V14.6c-.4.1-.7.1-.9.2zm-17.5 5.4c-4 1.2-8.4 2.6-12.7 3.9 1.2-4.7 3.6-9.4 6.4-12.5 1.1-1.1 2.6-2.4 4.3-3.2 1.7 3.6 2.1 8.5 2 11.8zM49.1 4.3c1.4 0 2.6.3 3.6.9-1.6.8-3.2 2.1-4.7 3.6-3.8 4.1-6.7 10.5-7.9 16.6-3.6 1.1-7.2 2.2-10.5 3.2 2.1-9.5 10.2-24 19.5-24.3zm-11.7 55c.4 6.4 17.3 7.8 18.3 22.9.7 11.9-6.3 20-16.4 20.6-12.2.8-18.9-6.4-18.9-6.4l2.6-11s6.7 5.1 12.1 4.7c3.5-.2 4.8-3.1 4.7-5.1-.5-8.4-14.3-7.9-15.2-21.7-.8-11.5 6.8-23.2 23.6-24.3 6.5-.4 9.8 1.2 9.8 1.2l-3.8 14.4s-4.3-2-9.4-1.6c-7.4.5-7.5 5.2-7.4 6.3zM61.2 19c0-3-.4-7.3-1.8-10.9 4.6.9 6.8 6 7.8 9.1-1.8.5-3.8 1.1-6 1.8zM78.1 123.9l31.4-7.8S96 24.8 95.9 24.2c-.1-.6-.6-1-1.1-1-.5 0-9.3-.2-9.3-.2s-5.4-5.2-7.4-7.2v108.1z"/></svg>';
 
         Nav::extend(function ($nav) use ($shopifySvg) {
-            $nav->create('Shopify')
-                ->icon($shopifySvg)
-                ->section('Tools')
-                ->can(auth()->user()->can('access shopify'))
-                ->route('shopify.index');
+            $collectionsNav = $nav->content('Collections');
 
-            // Hide the variants from the nav bar.
-            // TODO: Is there a way to hide this all together?
-            $nav->content('Collections')
-                ->children(function () {
-                    return Collection::all()->sortBy->title()->filter(function ($item) {
-                        return $item->handle() !== 'variants';
-                    })->map(function ($collection) {
-                        return Nav::item($collection->title())
-                            ->url($collection->showUrl())
-                            ->can('view', $collection);
-                    });
+            $children = $collectionsNav->children()()
+                ->reject(function ($item) {
+                    if (in_array($item->id(), ['::variants', '::products'])) {
+                        return true;
+                    }
+                });
+
+            $collectionsNav->children(function () use ($children) {
+                    return $children;
+                });
+
+            $taxonomiesNav = $nav->content('Taxonomies');
+
+            $children = $taxonomiesNav->children()()
+                ->reject(function ($item) {
+                    if (in_array($item->id(), ['::product_collections', '::product_tags', '::product_type', '::product_vendor'])) {
+                        return true;
+                    }
+                });
+
+            $taxonomiesNav->children(function () use ($children) {
+                    return $children;
+                });
+
+            $nav->create(__('Shopify'))
+                ->section('Shopify')
+                ->icon($shopifySvg)
+                ->route('collections.show', 'products')
+                ->children(function () use ($nav) {
+                    $children[] = $nav->create(__('Products'))
+                        ->route('collections.show', 'products')
+                        ->can('view', Collection::find('products'));
+
+                    $children[] = $nav->create(__('Collections'))
+                        ->route('taxonomies.show', 'collections')
+                        ->can('view', Taxonomy::find('collections'));
+
+                    $children[] = $nav->create(__('Tags'))
+                        ->route('taxonomies.show', 'tags')
+                        ->can('view', Taxonomy::find('tags'));
+
+                    $children[] = $nav->create(__('Product Types'))
+                        ->route('taxonomies.show', 'type')
+                        ->can('view', Taxonomy::find('type'));
+
+                    $children[] = $nav->create(__('Vendors'))
+                        ->route('taxonomies.show', 'vendor')
+                        ->can('view', Taxonomy::find('vendor'));
+
+                    $children[] = $nav->create(__('Settings'))
+                        ->can(auth()->user()->can('access shopify'))
+                        ->route('shopify.index');
+
+                    return $children;
                 });
         });
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -128,33 +128,31 @@ class ServiceProvider extends AddonServiceProvider
                 ->section('Shopify')
                 ->icon($shopifySvg)
                 ->route('collections.show', 'products')
-                ->children(function () use ($nav) {
-                    $children[] = $nav->create(__('Products'))
+                ->children([
+                    $nav->create(__('Products'))
                         ->route('collections.show', 'products')
-                        ->can('view', Collection::find('products'));
+                        ->can('view', Collection::find('products')),
 
-                    $children[] = $nav->create(__('Collections'))
+                    $nav->create(__('Collections'))
                         ->route('taxonomies.show', 'collections')
-                        ->can('view', Taxonomy::find('collections'));
+                        ->can('view', Taxonomy::find('collections')),
 
-                    $children[] = $nav->create(__('Tags'))
+                    $nav->create(__('Tags'))
                         ->route('taxonomies.show', 'tags')
-                        ->can('view', Taxonomy::find('tags'));
+                        ->can('view', Taxonomy::find('tags')),
 
-                    $children[] = $nav->create(__('Product Types'))
+                    $nav->create(__('Product Types'))
                         ->route('taxonomies.show', 'type')
-                        ->can('view', Taxonomy::find('type'));
+                        ->can('view', Taxonomy::find('type')),
 
-                    $children[] = $nav->create(__('Vendors'))
+                    $nav->create(__('Vendors'))
                         ->route('taxonomies.show', 'vendor')
-                        ->can('view', Taxonomy::find('vendor'));
+                        ->can('view', Taxonomy::find('vendor')),
 
-                    $children[] = $nav->create(__('Settings'))
-                        ->can(auth()->user()->can('access shopify'))
-                        ->route('shopify.index');
-
-                    return $children;
-                });
+                    $nav->create(__('Settings'))
+                        ->route('shopify.index')
+                        ->can('access shopify'),
+                ]);
         });
     }
 


### PR DESCRIPTION
This PR creates a `Shopify` nav section:

<img width="291" alt="Screenshot 2023-09-19 at 16 34 16" src="https://github.com/statamic-rad-pack/shopify/assets/51899/706d1b72-9317-4e69-a274-b6abc38a4e56">

Closes #164 
