### PR TITLE
Use Shopify's official PHP library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "phpclassic/php-shopify": "^1.1",
         "pixelfear/composer-dist-plugin": "^0.1",
+        "shopify/shopify-api": "dev-main",
         "statamic/cms": "^4.0"
     },
     "require-dev": {

--- a/config/shopify.php
+++ b/config/shopify.php
@@ -90,7 +90,7 @@ return [
      * Please note you having more than 1 process running at once on this queue may cause issues.
      */
     'queue' => env('SHOPIFY_JOB_QUEUE', 'default'),
-    
+
     /**
      * What class should we use to parse metafields
      */

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,10 @@
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <env name="MAIL_DRIVER" value="array"/>
+    <env name="SHOPIFY_APP_URL" value="https://mystore.myshopify.app"/>
+    <env name="SHOPIFY_AUTH_KEY" value="some-key"/>
+    <env name="SHOPIFY_AUTH_PASSWORD" value="some-password"/>
+    <env name="SHOPIFY_ADMIN_TOKEN" value="admin-token"/>
   </php>
   <source>
     <include>

--- a/src/Commands/ShopifyImportSingleProduct.php
+++ b/src/Commands/ShopifyImportSingleProduct.php
@@ -3,8 +3,9 @@
 namespace StatamicRadPack\Shopify\Commands;
 
 use Illuminate\Console\Command;
-use PHPShopify\ShopifySDK;
+use Shopify\Clients\Rest;
 use Statamic\Console\RunsInPlease;
+use Statamic\Support\Arr;
 use StatamicRadPack\Shopify\Jobs\ImportSingleProductJob;
 
 class ShopifyImportSingleProduct extends Command
@@ -24,8 +25,20 @@ class ShopifyImportSingleProduct extends Command
         $this->info('Fetching data for product '.$this->argument('productId'));
 
         // Fetch Single Product
-        $shopify = new ShopifySDK();
-        $product = $shopify->Product($this->argument('productId'))->get();
+        $client = app(Rest::class);
+        $response = $client->get(path: 'products/'.$this->argument('productId'));
+
+        if ($response->getStatusCode() != 200) {
+            $this->error('Failed to retrieve product');
+            return;
+        }
+
+        $product = Arr::get($response->getDecodedBody(), 'product', []);
+
+        if (!$product) {
+            $this->error('Failed to retrieve product');
+            return;
+        }
 
         // Pass to import Job.
         ImportSingleProductJob::dispatch($product)

--- a/src/Http/Controllers/Webhooks/OrderCreateController.php
+++ b/src/Http/Controllers/Webhooks/OrderCreateController.php
@@ -3,7 +3,8 @@
 namespace StatamicRadPack\Shopify\Http\Controllers\Webhooks;
 
 use Illuminate\Http\Request;
-use PHPShopify\ShopifySDK;
+use Shopify\Clients\Rest;
+use Statamic\Support\Arr;
 use StatamicRadPack\Shopify\Events;
 use StatamicRadPack\Shopify\Jobs\ImportSingleProductJob;
 
@@ -23,7 +24,7 @@ class OrderCreateController extends WebhooksController
         $data = json_decode($data);
 
         // Fetch Single Product
-        $shopify = new ShopifySDK();
+        $shopify = app(Rest::class);
 
         foreach ($data->line_items as $item) {
             $product = $shopify->Product($item->product_id)->get();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -174,7 +174,7 @@ class ServiceProvider extends AddonServiceProvider
         );
 
         $this->app->bind(Rest::class, function ($app) {
-            return new Rest(config('shopify.url'), config('shopify.auth_password'));
+            return new Rest(config('shopify.url'), config('shopify.admin_token'));
         });
     }
 


### PR DESCRIPTION
This PR switches to using the official PHP library, which gives us REST, GraphQL and StorefrontAPI access.

https://github.com/Shopify/shopify-api-php

I had to target dev-main as they havent tagged a release in a while... hopefully thats not a bad sign. Theres been plenty of commits, just no tags.