### PR TITLE
Support multi-site / Shopify translated fields

### DIFF
--- a/docs/content/en/CMS/multisite.md
+++ b/docs/content/en/CMS/multisite.md
@@ -1,0 +1,21 @@
+---
+title: Multisite
+category: CMS
+position: 8
+---
+
+You can make use of Statamic's inbuilt multi-site features to bring your Shopify translations to your products, variants and collections.
+
+## Setting Up Your API Key
+
+Ensure your API key has enabled the `read_translations` permission for this feature to work.
+
+## Setting up Statamic Collections and Taxonomies
+
+You need to enable multi-site on the `Products` collection and `Collections`, `Product Types`, `Tags` and `Vendor` taxonomies. You can do this by editing the configuration and adding the sites you want to enable to the `sites` field.
+
+On the Products collection ensure that `Propogate` is toggled on, and that the `Origin Behaviour` is set to `Use the site the entry was created in`.
+
+## How it works
+
+Now when your product or collection is updated we will check Shopify for any translations matching the `locale` of your Statamic site. Where they are found, the locale entry in Statamic is updated with those translations.

--- a/docs/content/en/CMS/multisite.md
+++ b/docs/content/en/CMS/multisite.md
@@ -4,7 +4,7 @@ category: CMS
 position: 8
 ---
 
-You can make use of Statamic's inbuilt multi-site features to bring your Shopify translations to your products, variants and collections.
+You can make use of Statamic's multi-site features to bring your Shopify translations to your products, variants and collections.
 
 ## Setting Up Your API Key
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,7 @@
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <env name="MAIL_DRIVER" value="array"/>
-    <env name="SHOPIFY_APP_URL" value="https://mystore.myshopify.app"/>
+    <env name="SHOPIFY_APP_URL" value="mystore.myshopify.app"/>
     <env name="SHOPIFY_AUTH_KEY" value="some-key"/>
     <env name="SHOPIFY_AUTH_PASSWORD" value="some-password"/>
     <env name="SHOPIFY_ADMIN_TOKEN" value="admin-token"/>

--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -86,7 +86,7 @@ class ImportSingleProductJob implements ShouldQueue
         if (! $entry) {
             $entry = Entry::make()
                 ->collection('products')
-                ->site(Site::default()->handle())
+                ->locale(Site::default()->handle())
                 ->slug($this->data['handle']);
         }
 
@@ -155,10 +155,10 @@ class ImportSingleProductJob implements ShouldQueue
 
                 $response = app(Graphql::class)->query(['query' => $query]);
 
-                $translations = Arr::get($response->getDecodedBody(), 'data.translatableResource.translations', []);
+                $translations = Arr::get($response->getDecodedBody(), 'translatableResource.translatableContent', []);
 
                 if ($translations) {
-                    $localizedEntry = $entry->in($site);
+                    $localizedEntry = $entry->in($site->handle());
 
                     if (! $localizedEntry) {
                         $localizedEntry = $entry->makeLocalization($site);
@@ -237,8 +237,8 @@ class ImportSingleProductJob implements ShouldQueue
                 'grams' => $variant['grams'],
                 'requires_shipping' => $variant['requires_shipping'],
                 'option1' => $variant['option1'],
-                'option2' => $variant['option2'],
-                'option3' => $variant['option3'],
+                'option2' => $variant['option2'] ?? '',
+                'option3' => $variant['option3'] ?? '',
                 'storefront_id' => base64_encode($variant['admin_graphql_api_id'])
             ];
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,11 @@
 namespace StatamicRadPack\Shopify;
 
 use Illuminate\Support\Facades\Artisan;
-use PHPShopify\ShopifySDK;
+use Shopify\Auth\FileSessionStorage;
+use Shopify\Auth\Session;
+use Shopify\Clients\Graphql;
+use Shopify\Clients\Rest;
+use Shopify\Context;
 use Statamic\Facades\Collection;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
@@ -159,17 +163,13 @@ class ServiceProvider extends AddonServiceProvider
 
     private function setShopifyApiConfig(): void
     {
-        $config = [];
-        $config['ShopUrl'] = config('shopify.url');
+        $this->app->bind(Rest::class, function ($app) {
+            return new Rest(config('shopify.url'), config('shopify.auth_password'));
+        });
 
-        if (config('shopify.admin_token')) {
-            $config['AccessToken'] = config('shopify.admin_token');
-        } else {
-            $config['ApiKey'] = config('shopify.auth_key');
-            $config['Password'] = config('shopify.auth_password');
-        }
-
-        ShopifySDK::config($config);
+        $this->app->bind(Graphql::class, function ($app) {
+            return new Graphql(config('shopify.url'), config('shopify.auth_password'));
+        });
     }
 
     private function publishAssets(): void

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,6 @@ namespace StatamicRadPack\Shopify;
 
 use Illuminate\Support\Facades\Artisan;
 use Shopify\Auth\FileSessionStorage;
-use Shopify\Auth\Session;
 use Shopify\Clients\Graphql;
 use Shopify\Clients\Rest;
 use Shopify\Context;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -164,11 +164,11 @@ class ServiceProvider extends AddonServiceProvider
     private function setShopifyApiConfig(): void
     {
         $this->app->bind(Rest::class, function ($app) {
-            return new Rest(config('shopify.url'), config('shopify.auth_password'));
+            return new Rest(config('shopify.url'), config('shopify.admin_token'));
         });
 
         $this->app->bind(Graphql::class, function ($app) {
-            return new Graphql(config('shopify.url'), config('shopify.auth_password'));
+            return new Graphql(config('shopify.url'), config('shopify.admin_token'));
         });
     }
 

--- a/tests/Unit/JobsTest.php
+++ b/tests/Unit/JobsTest.php
@@ -1,0 +1,487 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Tests\Unit;
+
+use Mockery\MockInterface;
+use Shopify\Clients\Graphql;
+use Shopify\Clients\HttpResponse;
+use Shopify\Clients\Rest;
+use Shopify\Clients\RestResponse;
+use Statamic\Facades;
+use StatamicRadPack\Shopify\Jobs;
+use StatamicRadPack\Shopify\Tests\TestCase;
+
+class JobsTest extends TestCase
+{
+    /** @test */
+    public function imports_collections_for_product()
+    {
+        Facades\Taxonomy::make()->handle('collections')->save();
+
+        $product = tap(Facades\Entry::make()
+            ->collection('products')
+            ->id('product-1')
+            ->slug('product-1')
+        )->save();
+
+        $this->mock(Rest::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('get')
+                ->andReturn(new RestResponse(
+                    status: 200,
+                    body: '{
+                      "metafields": [
+                        {
+                          "id": 1069228981,
+                          "namespace": "my_fields",
+                          "key": "sponsor",
+                          "value": "Shopify",
+                          "description": null,
+                          "owner_id": 382285388,
+                          "created_at": "2023-10-03T13:26:51-04:00",
+                          "updated_at": "2023-10-03T13:26:51-04:00",
+                          "owner_resource": "blog",
+                          "type": "single_line_text_field",
+                          "admin_graphql_api_id": "gid://shopify/Metafield/1069228981"
+                        }
+                      ]
+                    }'
+                ));
+        });
+
+        $collections = json_decode('[{"id": 841564295,"handle": "ipods","title": "IPods","updated_at": "2008-02-01T19:00:00-05:00","body_html": "<p>The best selling ipod ever</p>","published_at": "2008-02-01T19:00:00-05:00","sort_order": "manual","template_suffix": null,"published_scope": "web","admin_graphql_api_id": "gid://shopify/Collection/841564295"},{"id": 395646240,"handle": "ipods_two","title": "IPods Two","updated_at": "2008-02-01T19:00:00-05:00","body_html": "<p>The best selling ipod ever. Again</p>","published_at": "2008-02-01T19:00:00-05:00","sort_order": "manual","template_suffix": null,"published_scope": "web","admin_graphql_api_id": "gid://shopify/Collection/395646240"},{"id": 691652237,"handle": "non-ipods","title": "Non Ipods","updated_at": "2013-02-01T19:00:00-05:00","body_html": "<p>No ipods here</p>","published_at": "2013-02-01T19:00:00-05:00","sort_order": "manual","template_suffix": null,"published_scope": "web","admin_graphql_api_id": "gid://shopify/Collection/691652237"}]', true);
+
+        Jobs\ImportCollectionsForProductJob::dispatch($collections, $product);
+
+        // check collection terms are created
+        $this->assertSame(['ipods', 'ipods_two', 'non-ipods'], $product->fresh()->collections);
+
+        // check term data is added
+        $term = Facades\Term::query()->where('taxonomy', 'collections')->first();
+        $this->assertSame($term->get('collection_id'), 841564295);
+
+        // check metadata is added
+        $this->assertSame($term->get('sponsor'), 'Shopify');
+    }
+
+    /** @test */
+    public function imports_collections_translations_for_product()
+    {
+        Facades\Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR'],
+        ]]);
+
+        Facades\Taxonomy::make()->handle('collections')->sites(['en', 'fr'])->save();
+
+        $product = tap(Facades\Entry::make()
+            ->collection('products')
+            ->id('product-1')
+            ->slug('product-1')
+        )->save();
+
+        $this->mock(Rest::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('get')
+                ->andReturn(new RestResponse(
+                    status: 200,
+                    body: '{
+                      "metafields": [
+                        {
+                          "id": 1069228981,
+                          "namespace": "my_fields",
+                          "key": "sponsor",
+                          "value": "Shopify",
+                          "description": null,
+                          "owner_id": 382285388,
+                          "created_at": "2023-10-03T13:26:51-04:00",
+                          "updated_at": "2023-10-03T13:26:51-04:00",
+                          "owner_resource": "blog",
+                          "type": "single_line_text_field",
+                          "admin_graphql_api_id": "gid://shopify/Metafield/1069228981"
+                        }
+                      ]
+                    }'
+                ));
+        });
+
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('query')
+                ->andReturn(new HttpResponse(
+                    status: 200,
+                    body: '{
+                      "translatableResource": {
+                        "resourceId": "gid://shopify/Collection/1007901140",
+                        "translatableContent": [
+                          {
+                            "key": "title",
+                            "value": "Featured items",
+                            "digest": "a18b34037fda5b1afd720d4b85b86a8a75b5e389452f84f5b6d2b8e210869fd7",
+                            "locale": "en"
+                          },
+                          {
+                            "key": "body_html",
+                            "value": null,
+                            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "locale": "en"
+                          },
+                          {
+                            "key": "meta_title",
+                            "value": null,
+                            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "locale": "en"
+                          },
+                          {
+                            "key": "meta_description",
+                            "value": null,
+                            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "locale": "en"
+                          }
+                        ]
+                      }
+                    }'
+                ));
+        });
+
+        $collections = json_decode('[{"id": 841564295,"handle": "ipods","title": "IPods","updated_at": "2008-02-01T19:00:00-05:00","body_html": "<p>The best selling ipod ever</p>","published_at": "2008-02-01T19:00:00-05:00","sort_order": "manual","template_suffix": null,"published_scope": "web","admin_graphql_api_id": "gid://shopify/Collection/841564295"},{"id": 395646240,"handle": "ipods_two","title": "IPods Two","updated_at": "2008-02-01T19:00:00-05:00","body_html": "<p>The best selling ipod ever. Again</p>","published_at": "2008-02-01T19:00:00-05:00","sort_order": "manual","template_suffix": null,"published_scope": "web","admin_graphql_api_id": "gid://shopify/Collection/395646240"},{"id": 691652237,"handle": "non-ipods","title": "Non Ipods","updated_at": "2013-02-01T19:00:00-05:00","body_html": "<p>No ipods here</p>","published_at": "2013-02-01T19:00:00-05:00","sort_order": "manual","template_suffix": null,"published_scope": "web","admin_graphql_api_id": "gid://shopify/Collection/691652237"}]', true);
+
+        Jobs\ImportCollectionsForProductJob::dispatch($collections, $product);
+
+        // check term data is added
+        $term = Facades\Term::query()->where('taxonomy', 'collections')->first()->in('fr');
+
+        // check translation data is added
+        $this->assertSame($term->get('title'), 'Featured items');
+    }
+
+    /** @test */
+    public function imports_product()
+    {
+        $data = json_decode('{
+            "id": 1072481042,
+            "title": "Burton Custom Freestyle 151",
+            "body_html": "<strong>Good snowboard!</strong>",
+            "vendor": "Burton",
+            "product_type": "Snowboard",
+            "created_at": "2023-10-03T13:23:57-04:00",
+            "handle": "burton-custom-freestyle-151",
+            "updated_at": "2023-10-03T13:23:57-04:00",
+            "published_at": null,
+            "template_suffix": null,
+            "published_scope": "web",
+            "tags": "",
+            "status": "draft",
+            "admin_graphql_api_id": "gid://shopify/Product/1072481042",
+            "variants": [
+              {
+                "id": 1070325019,
+                "product_id": 1072481042,
+                "title": "Default Title",
+                "price": "0.00",
+                "sku": "",
+                "position": 1,
+                "inventory_policy": "deny",
+                "compare_at_price": null,
+                "fulfillment_service": "manual",
+                "inventory_management": null,
+                "option1": "Default Title",
+                "option2": null,
+                "option3": null,
+                "created_at": "2023-10-03T13:23:57-04:00",
+                "updated_at": "2023-10-03T13:23:57-04:00",
+                "taxable": true,
+                "barcode": null,
+                "grams": 0,
+                "image_id": null,
+                "weight": 0,
+                "weight_unit": "lb",
+                "inventory_item_id": 1070325019,
+                "inventory_quantity": 0,
+                "old_inventory_quantity": 0,
+                "presentment_prices": [
+                  {
+                    "price": {
+                      "amount": "0.00",
+                      "currency_code": "USD"
+                    },
+                    "compare_at_price": null
+                  }
+                ],
+                "requires_shipping": true,
+                "admin_graphql_api_id": "gid://shopify/ProductVariant/1070325019"
+              }
+            ],
+            "options": [
+              {
+                "id": 1055547176,
+                "product_id": 1072481042,
+                "name": "Title",
+                "position": 1,
+                "values": [
+                  "Default Title"
+                ]
+              }
+            ],
+            "images": [],
+            "image": null
+        }', true);
+
+        Facades\Collection::make('products')->save();
+        Facades\Taxonomy::make()->handle('collections')->save();
+        Facades\Taxonomy::make()->handle('tags')->save();
+        Facades\Taxonomy::make()->handle('type')->save();
+        Facades\Taxonomy::make()->handle('vendor')->save();
+
+        $this->mock(Rest::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('get')
+                ->with('custom_collections', [], ['limit' => 30, 'product_id' => 1072481042])
+                ->andReturn(new RestResponse(
+                    status: 200,
+                    body: '{
+                      "custom_collections": [
+                        {
+                          "id": 841564295,
+                          "handle": "ipods",
+                          "title": "IPods",
+                          "updated_at": "2008-02-01T19:00:00-05:00",
+                          "body_html": "<p>The best selling ipod ever</p>",
+                          "published_at": "2008-02-01T19:00:00-05:00",
+                          "sort_order": "manual",
+                          "template_suffix": null,
+                          "published_scope": "web",
+                          "admin_graphql_api_id": "gid://shopify/Collection/841564295"
+                        }
+                    ]
+                }'
+                ));
+
+            $mock
+                ->shouldReceive('get')
+                ->with('smart_collections', [], ['limit' => 30, 'product_id' => 1072481042])
+                ->andReturn(new RestResponse(
+                    status: 200,
+                    body: '{
+                      "smart_collections": [
+                        {
+                          "id": 1063001323,
+                          "handle": "ipods-1",
+                          "title": "IPods",
+                          "updated_at": "2023-10-03T13:23:35-04:00",
+                          "body_html": null,
+                          "published_at": "2023-10-03T13:23:35-04:00",
+                          "sort_order": "best-selling",
+                          "template_suffix": null,
+                          "disjunctive": false,
+                          "rules": [
+                            {
+                              "column": "title",
+                              "relation": "starts_with",
+                              "condition": "iPod"
+                            }
+                          ],
+                          "published_scope": "web",
+                          "admin_graphql_api_id": "gid://shopify/Collection/1063001323"
+                        }
+                      ]
+                }'
+                ));
+        });
+
+        Jobs\ImportSingleProductJob::dispatch($data);
+
+        $entry = Facades\Entry::whereCollection('products')->first();
+
+        $this->assertSame($entry->product_id, 1072481042);
+        $this->assertSame($entry->get('vendor'), ['burton']);
+        $this->assertSame($entry->get('type'), ['snowboard']);
+        $this->assertSame($entry->get('collections'), ['ipods', 'ipods-1']);
+    }
+
+    /** @test */
+    public function imports_translations_for_product()
+    {
+        Facades\Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR'],
+        ]]);
+
+       $data = json_decode('{
+            "id": 1072481042,
+            "title": "Burton Custom Freestyle 151",
+            "body_html": "<strong>Good snowboard!</strong>",
+            "vendor": "Burton",
+            "product_type": "Snowboard",
+            "created_at": "2023-10-03T13:23:57-04:00",
+            "handle": "burton-custom-freestyle-151",
+            "updated_at": "2023-10-03T13:23:57-04:00",
+            "published_at": null,
+            "template_suffix": null,
+            "published_scope": "web",
+            "tags": "",
+            "status": "draft",
+            "admin_graphql_api_id": "gid://shopify/Product/1072481042",
+            "variants": [
+              {
+                "id": 1070325019,
+                "product_id": 1072481042,
+                "title": "Default Title",
+                "price": "0.00",
+                "sku": "",
+                "position": 1,
+                "inventory_policy": "deny",
+                "compare_at_price": null,
+                "fulfillment_service": "manual",
+                "inventory_management": null,
+                "option1": "Default Title",
+                "option2": null,
+                "option3": null,
+                "created_at": "2023-10-03T13:23:57-04:00",
+                "updated_at": "2023-10-03T13:23:57-04:00",
+                "taxable": true,
+                "barcode": null,
+                "grams": 0,
+                "image_id": null,
+                "weight": 0,
+                "weight_unit": "lb",
+                "inventory_item_id": 1070325019,
+                "inventory_quantity": 0,
+                "old_inventory_quantity": 0,
+                "presentment_prices": [
+                  {
+                    "price": {
+                      "amount": "0.00",
+                      "currency_code": "USD"
+                    },
+                    "compare_at_price": null
+                  }
+                ],
+                "requires_shipping": true,
+                "admin_graphql_api_id": "gid://shopify/ProductVariant/1070325019"
+              }
+            ],
+            "options": [
+              {
+                "id": 1055547176,
+                "product_id": 1072481042,
+                "name": "Title",
+                "position": 1,
+                "values": [
+                  "Default Title"
+                ]
+              }
+            ],
+            "images": [],
+            "image": null
+        }', true);
+
+        Facades\Collection::make('products')->sites(['en', 'fr'])->save();
+        Facades\Taxonomy::make()->handle('collections')->save();
+        Facades\Taxonomy::make()->handle('tags')->save();
+        Facades\Taxonomy::make()->handle('type')->save();
+        Facades\Taxonomy::make()->handle('vendor')->save();
+
+        $this->mock(Rest::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('get')
+                ->with('custom_collections', [], ['limit' => 30, 'product_id' => 1072481042])
+                ->andReturn(new RestResponse(
+                    status: 200,
+                    body: '{
+                      "custom_collections": [
+                        {
+                          "id": 841564295,
+                          "handle": "ipods",
+                          "title": "IPods",
+                          "updated_at": "2008-02-01T19:00:00-05:00",
+                          "body_html": "<p>The best selling ipod ever</p>",
+                          "published_at": "2008-02-01T19:00:00-05:00",
+                          "sort_order": "manual",
+                          "template_suffix": null,
+                          "published_scope": "web",
+                          "admin_graphql_api_id": "gid://shopify/Collection/841564295"
+                        }
+                    ]
+                }'
+                ));
+
+            $mock
+                ->shouldReceive('get')
+                ->with('smart_collections', [], ['limit' => 30, 'product_id' => 1072481042])
+                ->andReturn(new RestResponse(
+                    status: 200,
+                    body: '{
+                      "smart_collections": [
+                        {
+                          "id": 1063001323,
+                          "handle": "ipods-1",
+                          "title": "IPods",
+                          "updated_at": "2023-10-03T13:23:35-04:00",
+                          "body_html": null,
+                          "published_at": "2023-10-03T13:23:35-04:00",
+                          "sort_order": "best-selling",
+                          "template_suffix": null,
+                          "disjunctive": false,
+                          "rules": [
+                            {
+                              "column": "title",
+                              "relation": "starts_with",
+                              "condition": "iPod"
+                            }
+                          ],
+                          "published_scope": "web",
+                          "admin_graphql_api_id": "gid://shopify/Collection/1063001323"
+                        }
+                      ]
+                }'
+                ));
+        });
+
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('query')
+                ->andReturn(new HttpResponse(
+                    status: 200,
+                    body: '{
+                      "translatableResource": {
+                        "resourceId": "gid://shopify/Product/1007901140",
+                        "translatableContent": [
+                          {
+                            "key": "title",
+                            "value": "Featured items",
+                            "digest": "a18b34037fda5b1afd720d4b85b86a8a75b5e389452f84f5b6d2b8e210869fd7",
+                            "locale": "en"
+                          },
+                          {
+                            "key": "body_html",
+                            "value": null,
+                            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "locale": "en"
+                          },
+                          {
+                            "key": "meta_title",
+                            "value": null,
+                            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "locale": "en"
+                          },
+                          {
+                            "key": "meta_description",
+                            "value": null,
+                            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                            "locale": "en"
+                          }
+                        ]
+                      }
+                    }'
+                ));
+        });
+
+        Jobs\ImportSingleProductJob::dispatch($data);
+
+        $entry = Facades\Entry::whereCollection('products')->firstWhere('locale', 'fr');
+
+        $this->assertNotNull($entry);
+        $this->assertSame($entry->title, 'Featured items');
+    }
+}


### PR DESCRIPTION
This PR syncs Shopify translations over to multi-site locales of products, collections, vendors and types.

Requires https://github.com/statamic-rad-pack/shopify/pull/183 to be merged