### PR TITLE
Move webhook validation to middleware

### DIFF
--- a/routes/actions.php
+++ b/routes/actions.php
@@ -9,6 +9,7 @@ use StatamicRadPack\Shopify\Http\Controllers\Webhooks\CustomerDeleteController;
 use StatamicRadPack\Shopify\Http\Controllers\Webhooks\OrderCreateController;
 use StatamicRadPack\Shopify\Http\Controllers\Webhooks\ProductCreateUpdateController;
 use StatamicRadPack\Shopify\Http\Controllers\Webhooks\ProductDeleteController;
+use StatamicRadPack\Shopify\Http\Middleware\VerifyShopifyHeaders;
 
 Route::name('shopify.')
     ->group(function () {
@@ -29,6 +30,7 @@ Route::name('shopify.')
 
         Route::prefix('webhook')
             ->withoutMiddleware([VerifyCsrfToken::class])
+            ->middleware([VerifyShopifyHeaders::class])
             ->group(function () {
 
                 Route::post('order', OrderCreateController::class)

--- a/src/Http/Controllers/Webhooks/CustomerCreateUpdateController.php
+++ b/src/Http/Controllers/Webhooks/CustomerCreateUpdateController.php
@@ -21,16 +21,8 @@ class CustomerCreateUpdateController extends WebhooksController
 
     private function processWebhook(Request $request, Closure $eventCallback)
     {
-        $hmac_header = $request->header('X-Shopify-Hmac-Sha256');
-        $data = $request->getContent();
-        $verified = $this->verify($data, $hmac_header);
-
-        if (! $verified) {
-            return response()->json(['error' => true], 403);
-        }
-
         // Decode data
-        $data = json_decode($data);
+        $data = json_decode($request->getContent());
 
         $customerEntry = User::query()
             ->where('shopify_id', $data->id)

--- a/src/Http/Controllers/Webhooks/CustomerDeleteController.php
+++ b/src/Http/Controllers/Webhooks/CustomerDeleteController.php
@@ -10,16 +10,8 @@ class CustomerDeleteController extends WebhooksController
 {
     public function __invoke(Request $request)
     {
-        $hmac_header = $request->header('X-Shopify-Hmac-Sha256');
-        $data = $request->getContent();
-        $verified = $this->verify($data, $hmac_header);
-
-        if (! $verified) {
-            return response()->json(['error' => true], 403);
-        }
-
         // Decode data
-        $data = json_decode($data);
+        $data = json_decode($request->getContent());
 
         if (! is_object($data) && ! $data->id) {
             return;

--- a/src/Http/Controllers/Webhooks/OrderCreateController.php
+++ b/src/Http/Controllers/Webhooks/OrderCreateController.php
@@ -12,16 +12,8 @@ class OrderCreateController extends WebhooksController
 {
     public function __invoke(Request $request)
     {
-        $hmac_header = $request->header('X-Shopify-Hmac-Sha256');
-        $data = $request->getContent();
-        $verified = $this->verify($data, $hmac_header);
-
-        if (! $verified) {
-            return response()->json(['error' => true], 403);
-        }
-
         // Decode data
-        $data = json_decode($data);
+        $data = json_decode($request->getContent());
 
         // Fetch Single Product
         $shopify = app(Rest::class);

--- a/src/Http/Controllers/Webhooks/ProductCreateUpdateController.php
+++ b/src/Http/Controllers/Webhooks/ProductCreateUpdateController.php
@@ -21,17 +21,9 @@ class ProductCreateUpdateController extends WebhooksController
 
     private function processWebhook(Request $request, Closure $eventCallback)
     {
-        $hmac_header = $request->header('X-Shopify-Hmac-Sha256');
-        $data = $request->getContent();
-        $verified = $this->verify($data, $hmac_header);
-
-        if (! $verified) {
-            return response()->json(['error' => true], 403);
-        }
-
         // Decode data
-        $dataArray = json_decode($data, true);
-        $data = json_decode($data);
+        $dataArray = json_decode($request->getContent(), true);
+        $data = json_decode($request->getContent());
 
         // Dispatch job
         ImportSingleProductJob::dispatch($dataArray)->onQueue(config('shopify.queue'));

--- a/src/Http/Controllers/Webhooks/ProductDeleteController.php
+++ b/src/Http/Controllers/Webhooks/ProductDeleteController.php
@@ -10,16 +10,8 @@ class ProductDeleteController extends WebhooksController
 {
     public function __invoke(Request $request)
     {
-        $hmac_header = $request->header('X-Shopify-Hmac-Sha256');
-        $data = $request->getContent();
-        $verified = $this->verify($data, $hmac_header);
-
-        if (! $verified) {
-            return response()->json(['error' => true], 403);
-        }
-
         // Decode data
-        $data = json_decode($data);
+        $data = json_decode($request->getContent());
 
         if (! is_object($data) && ! $data->id) {
             return;

--- a/src/Http/Controllers/Webhooks/WebhooksController.php
+++ b/src/Http/Controllers/Webhooks/WebhooksController.php
@@ -6,17 +6,4 @@ use Statamic\Http\Controllers\CP\CpController;
 
 class WebhooksController extends CpController
 {
-    /**
-     * Verify integrity
-     */
-    protected function verify($data, $hmac_header): bool
-    {
-        if (config('shopify.ignore_webhook_integrity_check', false)) {
-            return true;
-        }
-
-        $calculated_hmac = base64_encode(hash_hmac('sha256', $data, config('shopify.webhook_secret'), true));
-
-        return hash_equals($hmac_header, $calculated_hmac);
-    }
 }

--- a/src/Http/Middleware/VerifyShopifyHeaders.php
+++ b/src/Http/Middleware/VerifyShopifyHeaders.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class VerifyShopifyHeaders
+{
+    /**
+     * before response sent back to browser
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $hmacHeader = $request->header('X-Shopify-Hmac-Sha256');
+        $data = $request->getContent();
+        $verified = $this->verify($data, $hmacHeader);
+
+        if (! $verified) {
+            return response()->json(['error' => true], 403);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Verify integrity
+     */
+    protected function verify($data, $hmacHeader): bool
+    {
+        if (config('shopify.ignore_webhook_integrity_check', false)) {
+            return true;
+        }
+
+        $calculatedHmac = base64_encode(hash_hmac('sha256', $data, config('shopify.webhook_secret'), true));
+
+        return hash_equals($hmacHeader, $calculatedHmac);
+    }
+}


### PR DESCRIPTION
This PR moves the webhook validation to a middleware to avoid code repetition.

Closes https://github.com/statamic-rad-pack/shopify/issues/187