### PR TITLE
Target Shopify PHP 5.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "pixelfear/composer-dist-plugin": "^0.1",
-        "shopify/shopify-api": "dev-main",
+        "shopify/shopify-api": "^5.1",
         "statamic/cms": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Not sure how the Shopify library does releases but packagist has a v5.1 (doesnt correspond to Github) which Craft are targeting, so lets run with that.

Edit: they are just using tags, not releases. Good to know going forward.