### PR TITLE
Fix connection defaulting to private app and make it configurable

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -54,6 +54,16 @@ return [
     'api_limit' => 30,
 
     /**
+     * Admin API version - Set this to a fixed value (eg 2023-07) or null to let the library decide
+     */
+    'api_version' => null,
+
+    /**
+     * Admin connection is a private app, defaults to false
+     */
+    'api_private_app' => false,
+
+    /**
      * Shop Currency
      */
     'currency' => '£',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -178,9 +178,9 @@ class ServiceProvider extends AddonServiceProvider
             scopes: ['read_metaobjects', 'read_products'],
             hostName: config('shopify.url'),
             sessionStorage: new FileSessionStorage('/tmp/php_sessions'),
-            apiVersion: '2023-04',
+            apiVersion: config('shopify.api_version') ?? '2023-07',
             isEmbeddedApp: false,
-            isPrivateApp: true,
+            isPrivateApp: config('shopify.api_private_app') ?? false,
         );
 
         $this->app->bind(Rest::class, function ($app) {


### PR DESCRIPTION
Add configuration options to allow private app to be an option rather than a requirement.
Also allow a specific api version to be (optionally) targeted.