### PR TITLE
Select default site for variants

### DIFF
--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -220,11 +220,13 @@ class ImportSingleProductJob implements ShouldQueue
             $entry = Entry::query()
                 ->where('collection', 'variants')
                 ->where('slug', $variant['id'])
+                ->where('site', Site::default()->handle())
                 ->first();
 
             if (! $entry) {
                 $entry = Entry::make()
                     ->collection('variants')
+                    ->locale(Site::default()->handle())
                     ->slug($variant['id']);
             }
 


### PR DESCRIPTION
Ensure we select the variant site, similar to what we do for products.

Closes https://github.com/statamic-rad-pack/shopify/issues/213