### PR TITLE
Support pagination on customer orders tag

### DIFF
--- a/docs/content/en/frontend/tags.md
+++ b/docs/content/en/frontend/tags.md
@@ -202,3 +202,9 @@ Return any Shopify addresses associated with the current logged in user, or the 
 {{ shopify:customer:orders customer_id="my_id" }} ... {{ /shopify:customer:orders }}
 
 ```
+
+This tag also supports pagination:
+
+```twig
+{{ shopify:customer:orders paginate="10" }} ... {{ /shopify:customer:orders }}
+```

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -1349,5 +1349,8 @@ window.shopifyToken = '1234';
 
         $this->actingAs($user);
         $this->assertEquals('450789469', $this->tag('{{ shopify:customer:orders }}{{ orders }}{{ id }}{{ /orders }}{{ /shopify:customer:orders }}'));
+
+        $this->assertEquals('450789469', $this->tag('{{ shopify:customer:orders paginate="1" }}{{ orders }}{{ id }}{{ /orders }}{{ /shopify:customer:orders }}'));
+        $this->assertEquals('1', $this->tag('{{ shopify:customer:orders paginate="1" }}{{ paginate:total_items }}{{ /shopify:customer:orders }}'));
     }
 }


### PR DESCRIPTION
This PR adds pagination to the customer orders tag:

eg

```antlers
{{ shopify:customer:orders paginate="10" }}
```