### PR TITLE
Don't set shopify context if a key isnt set

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -151,8 +151,12 @@ class ServiceProvider extends AddonServiceProvider
 
     private function setShopifyApiConfig(): void
     {
+        if (! $key = config('shopify.auth_key')) {
+            return;
+        }
+
         Context::initialize(
-            apiKey: config('shopify.auth_key'),
+            apiKey: $key,
             apiSecretKey: config('shopify.auth_password'),
             scopes: ['read_metaobjects', 'read_products'],
             hostName: config('shopify.url'),


### PR DESCRIPTION
If no key is set then Shopify's library throws an error, so lets avoid setting context if there is no key set.

Closes #217 