### PR TITLE
Add session_storage_path config

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -121,4 +121,9 @@ return [
      * What job should we use to update users in Shopify
      */
     'update_shopify_user_job' => \StatamicRadPack\Shopify\Jobs\CreateOrUpdateShopifyUser::class,
+
+    /**
+     * Where should the Shopify API client store its session data
+     */
+    'session_storage_path' => env('SHOPIFY_SESSION_STORAGE_PATH', '/tmp/php_sessions'),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -160,7 +160,7 @@ class ServiceProvider extends AddonServiceProvider
             apiSecretKey: config('shopify.auth_password'),
             scopes: ['read_metaobjects', 'read_products'],
             hostName: config('shopify.url'),
-            sessionStorage: new FileSessionStorage('/tmp/php_sessions'),
+            sessionStorage: new FileSessionStorage(config('shopify.session_storage_path', '/tmp/php_sessions')),
             apiVersion: config('shopify.api_version') ?? '2023-07',
             isEmbeddedApp: false,
             isPrivateApp: config('shopify.api_private_app') ?? false,


### PR DESCRIPTION
This PR adds a `session_storage_path` config and `SHOPIFY_SESSION_STORAGE_PATH` env variable so you can choose where to store sessions that the official Api client creates.

A bit annoying as we dont use sessions, but its a requirement for the client and seems to be causing issues with an invalid path in Windows environments.

Closes https://github.com/statamic-rad-pack/shopify/issues/220