### PR TITLE
Remove `respect_shopify_publish_status_and_dates` config

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -126,10 +126,4 @@ return [
      * Where should the Shopify API client store its session data
      */
     'session_storage_path' => env('SHOPIFY_SESSION_STORAGE_PATH', '/tmp/php_sessions'),
-
-    /**
-     * Should publish status and date be determined by Shopify's settings
-     * (this config is for backwards compatibility; this will not be configurable in the next major version)
-     */
-    'respect_shopify_publish_status_and_dates' => true,
 ];

--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -199,26 +199,23 @@ class ImportSingleProductJob implements ShouldQueue
 
             // publication state
             try {
-                // @deprecated: config will be removed in next major version
-                if (config('shopify.respect_shopify_publish_status_and_dates', false)) {
-                    $publicationStatus = collect(Arr::get($response->getDecodedBody(), 'data.product.resourcePublications.edges', []))
-                        ->where('node.publication.name', 'Online Store')
-                        ->map(function ($channel) {
-                            if (! $node = $channel['node'] ?? []) {
-                                return [];
-                            }
-
-                            return $node;
-                        })
-                        ->filter()
-                        ->first();
-
-                    if ($publicationStatus) {
-                        $entry->published($publicationStatus['isPublished'] ?? false);
-
-                        if ($entry->collection()->dated() && $publicationStatus['publishDate']) {
-                            $entry->date(Carbon::parse($publicationStatus['publishDate']));
+                $publicationStatus = collect(Arr::get($response->getDecodedBody(), 'data.product.resourcePublications.edges', []))
+                    ->where('node.publication.name', 'Online Store')
+                    ->map(function ($channel) {
+                        if (! $node = $channel['node'] ?? []) {
+                            return [];
                         }
+
+                        return $node;
+                    })
+                    ->filter()
+                    ->first();
+
+                if ($publicationStatus) {
+                    $entry->published($publicationStatus['isPublished'] ?? false);
+
+                    if ($entry->collection()->dated() && $publicationStatus['publishDate']) {
+                        $entry->date(Carbon::parse($publicationStatus['publishDate']));
                     }
                 }
             } catch (\Throwable $e) {


### PR DESCRIPTION
This PR removes the `respect_shopify_publish_status_and_dates` config and wrapper around it, in preparation for 4.x