### PR TITLE
Ensure future dated products get marked a published

### DIFF
--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -212,11 +212,19 @@ class ImportSingleProductJob implements ShouldQueue
                     ->first();
 
                 if ($publicationStatus) {
-                    $entry->published($publicationStatus['isPublished'] ?? false);
+                    $published = $publicationStatus['isPublished'] ?? false;
 
                     if ($entry->collection()->dated() && $publicationStatus['publishDate']) {
-                        $entry->date(Carbon::parse($publicationStatus['publishDate']));
+                        $publishDate = Carbon::parse($publicationStatus['publishDate']);
+
+                        $entry->date($publishDate);
+
+                        if (! $published && $publishDate->gt(now())) {
+                            $published = true;
+                        }
                     }
+
+                    $entry->published($published);
                 }
             } catch (\Throwable $e) {
                 Log::error('Could not manage publications status for product '.$this->data['id']);


### PR DESCRIPTION
This PR ensures that future dated products get marked as published, as their publicationStatus comes through as false until the date passes.