### PR TITLE
We don't need Product Create on setup

### DIFF
--- a/docs/content/en/CMS/webhooks.md
+++ b/docs/content/en/CMS/webhooks.md
@@ -51,16 +51,6 @@ https://YOURSITE/!/shopify/webhook/collection/delete
 ```
 
 
-## Product Create
-
-Rather than running the full import continuously you can add a webhook on **Product Creation** that sends the data to Statamic and queues the import of that one product.
-
-Your URL should point to the following endpoint:
-
-```bash
-https://YOURSITE/!/shopify/webhook/product/create
-```
-
 ## Product Update
 
 Similarly, rather than running the full import to catch any changes to products, you can add a webhook on **Product Update** that sends any updated data to Statamic and queues a refresh of that product.


### PR DESCRIPTION
As discussed in the linked issue - we don't need the product create web hook.

Closes https://github.com/statamic-rad-pack/shopify/issues/239