### PR TITLE
Prevent current timestamp being added to draft products

### DIFF
--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -65,7 +65,7 @@ class ImportSingleProductJob implements ShouldQueue
         $data = [
             'product_id' => $this->data['id'],
             'published' => $this->data['status'] === 'active' ? true : false,
-            'published_at' => Carbon::parse($this->data['published_at'])->format('Y-m-d H:i:s'),
+            'published_at' => $this->data['status'] === 'active' ? Carbon::parse($this->data['published_at'])->format('Y-m-d H:i:s') : null,
             'title' => (! $entry || config('shopify.overwrite.title')) ? $this->data['title'] : $entry->title,
             'content' => (! $entry || config('shopify.overwrite.content')) ? $this->data['body_html'] : $entry->content,
             'options' => $options,


### PR DESCRIPTION
I noticed that `published_at` timestamp gets added with the current date and time on draft products which was causing draft products to be committed to git as they had 'changed'. 

This PR should sort that :)