### PR TITLE
Types needs renamed to type in the product template

### DIFF
--- a/resources/views/product.antlers.html
+++ b/resources/views/product.antlers.html
@@ -22,13 +22,13 @@
         <div class="grid-cell">
             <div class="mb-8 prose">{{ content }}</div>
 
-            {{ if types }}
+            {{ if type }}
                 <div class="flex py-3 text-sm border-t border-b">
                     <span class="mr-3 font-medium">Types</span>
                     <span>
-                    {{ types }}
+                    {{ type }}
                         <a href="{{ url }}" class="hover:text-indigo-700">{{ title | ucfirst }}</a>
-                    {{ /types }}
+                    {{ /type }}
                     </span>
                 </div>
             {{ /if }}


### PR DESCRIPTION
I noticed in product.antlers.html that `types` should be `type` :) 