### PR TITLE
Temporary fix for failing product collections import

### DIFF
--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -130,7 +130,6 @@ class ImportSingleProductJob implements ShouldQueue
                     edges {
                        node {
                         id
-                        jsonValue
                         key
                         value
                       }


### PR DESCRIPTION
Hi Again,

I couldn't work out why the collections weren't importing for products. In this PR you'll see the fix.

The $response->getDecodedBody() on line 160ish was returning Field 'jsonValue' doesn't exist on type 'Metafield'

Removing the jsonValue did the trick, but I'm sure it will also cause issues for the metafields?

Can I suggest looking for errors on that response before running Arr::get($response->getDecodedBody(), 'data.product.collections.edges', []) too? It as that took a while to work out why it was quietly failing.