### PR TITLE
Fix created_at on order create

### DIFF
--- a/src/Http/Controllers/Webhooks/OrderCreateController.php
+++ b/src/Http/Controllers/Webhooks/OrderCreateController.php
@@ -28,7 +28,7 @@ class OrderCreateController extends WebhooksController
                 if ($product) {
                     ImportSingleProductJob::dispatch($product, [
                         'quantity' => [$item->sku => $item->quantity ?? 1],
-                        'date' => Carbon::parse($data['created_at']),
+                        'date' => Carbon::parse($data->created_at),
                     ])->onQueue(config('shopify.queue'));
                 }
             }


### PR DESCRIPTION
This PR fixes an issue on the OrderCreate controller where it was treating data as an array instead of an object.

Closes #262 