### PR TITLE
Remove hardcoded API version from JS client

### DIFF
--- a/resources/js/shopify/client.js
+++ b/resources/js/shopify/client.js
@@ -6,7 +6,7 @@ import { createStorefrontApiClient } from '@shopify/storefront-api-client';
  */
 const client = createStorefrontApiClient({
     storeDomain: window.shopifyConfig.url,
-    apiVersion: '2024-04',
+    apiVersion: window.shopifyConfig.apiVersion ?? '2024-07',
     publicAccessToken: window.shopifyConfig.token,
 });
 

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -77,7 +77,7 @@ class Shopify extends Tags
     public function tokens()
     {
         return "<script>
-window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('shopify.url'))."', token: '".config('shopify.storefront_token')."', apiVersion: '".config('shopify.api_version', '2024-07')."' };
+window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('shopify.url'))."', token: '".config('shopify.storefront_token')."', apiVersion: '".(config('shopify.api_version') ?? '2024-07')."' };
 </script>";
     }
 

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -77,7 +77,7 @@ class Shopify extends Tags
     public function tokens()
     {
         return "<script>
-window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('shopify.url'))."', token: '".config('shopify.storefront_token')."' };
+window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('shopify.url'))."', token: '".config('shopify.storefront_token')."', apiVersion: '".config('shopify.api_version', '2024-07')."' };
 </script>";
     }
 

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -23,7 +23,7 @@ class TagsTest extends TestCase
         config()->set('shopify.storefront_token', '1234');
 
         $this->assertEquals(str_replace(["\r", "\n"], '', "<script>
-window.shopifyConfig = { url: 'abcd', token: '1234' };
+window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
 </script>"),
             str_replace(["\r", "\n"], '', $this->tag('{{ shopify:tokens }}'))
         );


### PR DESCRIPTION
This PR updates the JS client to use the API version set in the config, rather than hardcoded to `2024-04` (which is deprecated).