### PR TITLE
Setting of ENV Variables

### DIFF
--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -36,7 +36,7 @@ To set up a private app on Shopify for this add-on to use, use the following ste
     3. Click "Configure" next to Storefront API Integration.
     4. Enable `unauthenticated_read_product_listings`, `unauthenticated_read_product_tags`, `unauthenticated_read_product_inventory`, `unauthenticated_write_customers`, `unauthenticated_write_checkouts`, `unauthenticated_read_customers`, `unauthenticated_read_checkouts`, `unauthenticated_read_metaobjects`
     5. Click "Save" in the top right.
-6. Click the "API Credentials" tab. Add the `Admin API access token` to your `.env` as `SHOPIFY_ADMIN_TOKEN`, add `API key` as `SHOPIFY_AUTH_KEY`, add `API secret key` as both `SHOPIFY_AUTH_PASSWORD` and `SHOPIFY_WEBHOOK_SECRET`, and add `Storefront API access token` as `SHOPIFY_STOREFRONT_TOKEN`.
+6. Click the "API Credentials" tab. Add the `Admin API access token` to your `.env` as `SHOPIFY_ADMIN_TOKEN`, add `API key` as `SHOPIFY_AUTH_KEY`, add `API secret key` as  `SHOPIFY_AUTH_PASSWORD`, and add `Storefront API access token` as `SHOPIFY_STOREFRONT_TOKEN`.
 7. If you've configured the app properly you should see a button that says "Install App". Click this.
 
 


### PR DESCRIPTION
SHOPIFY_WEBHOOK_SECRET shouldn't be the API Secret Key. It's set separately as per the ENV Variables page.