### PR TITLE
Configurable Statamic collection handle

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -126,4 +126,10 @@ return [
      * Where should the Shopify API client store its session data
      */
     'session_storage_path' => env('SHOPIFY_SESSION_STORAGE_PATH', '/tmp/php_sessions'),
+
+    /**
+     * In which collection should the Shopify products be created
+     */
+    'collection_handle' => env('SHOPIFY_COLLECTION_HANDLE', 'products'),
+
 ];

--- a/src/Http/Controllers/CP/ProductsController.php
+++ b/src/Http/Controllers/CP/ProductsController.php
@@ -11,7 +11,7 @@ class ProductsController extends CpController
     public function index(): JsonResponse
     {
         $products = Entry::query()
-            ->where('collection', 'products')
+            ->where('collection', config('shopify.collection_handle'))
             ->get()
             ->map(function ($product) {
                 $values['title'] = $product->title;

--- a/src/Http/Controllers/Webhooks/ProductDeleteController.php
+++ b/src/Http/Controllers/Webhooks/ProductDeleteController.php
@@ -20,7 +20,7 @@ class ProductDeleteController extends WebhooksController
         Events\ProductDelete::dispatch($data);
 
         $productEntry = Entry::query()
-            ->where('collection', 'products')
+            ->where('collection', config('shopify.collection_handle'))
             ->where('product_id', $data->id)
             ->first();
 

--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -44,7 +44,7 @@ class ImportSingleProductJob implements ShouldQueue
     public function handle()
     {
         $entry = Entry::query()
-            ->where('collection', 'products')
+            ->where('collection', config('shopify.collection_handle'))
             ->where('site', Site::default()->handle())
             ->where('product_id', $this->data['id'])
             ->first();
@@ -86,7 +86,7 @@ class ImportSingleProductJob implements ShouldQueue
 
         if (! $entry) {
             $entry = Entry::make()
-                ->collection('products')
+                ->collection(config('shopify.collection_handle'))
                 ->locale(Site::default()->handle())
                 ->slug($this->data['handle']);
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -103,7 +103,7 @@ class ServiceProvider extends AddonServiceProvider
 
             $user = Facades\User::current();
 
-            $canViewSomething = $user->can('view', Facades\Collection::find('products'))
+            $canViewSomething = $user->can('view', Facades\Collection::find(config('shopify.collection_handle')))
                 || $user->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.collections')))
                 || $user->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.tags')))
                 || $user->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.type')))
@@ -117,12 +117,12 @@ class ServiceProvider extends AddonServiceProvider
             $nav->create(__('Shopify'))
                 ->section('Shopify')
                 ->icon($shopifySvg)
-                ->route('collections.show', 'products')
+                ->route('collections.show', config('shopify.collection_handle'))
                 ->children(function () use ($nav) {
                     return [
                         $nav->create(__('Products'))
-                            ->route('collections.show', 'products')
-                            ->can('view', Facades\Collection::find('products')),
+                            ->route('collections.show', config('shopify.collection_handle'))
+                            ->can('view', Facades\Collection::find(config('shopify.collection_handle'))),
 
                         $nav->create(__('Collections'))
                             ->route('taxonomies.show', 'collections')
@@ -233,9 +233,9 @@ class ServiceProvider extends AddonServiceProvider
                 ->save();
         }
 
-        if (! Facades\Collection::find('products')) {
+        if (! Facades\Collection::find(config('shopify.collection_handle'))) {
             $collection = tap(Facades\Collection::make()
-                ->handle('products')
+                ->handle(config('shopify.collection_handle'))
                 ->title('Products')
                 ->routes('/products/{slug}')
                 ->template('product')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,7 +38,7 @@ class TestCase extends AddonTestCase
                 ->setContents($blueprintContents)
                 ->save();
 
-            Facades\Collection::make('products')
+            Facades\Collection::make(config('shopify.collection_handle'))
                 ->save();
 
             $blueprintContents = Facades\YAML::parse(file_get_contents(__DIR__.'/../resources/blueprints/variant.yaml'));

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -21,7 +21,7 @@ class ActionsTest extends TestCase
                 'slug' => 'obi-wan',
                 'product_id' => 1,
             ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 

--- a/tests/Unit/ImportCollectionJobTest.php
+++ b/tests/Unit/ImportCollectionJobTest.php
@@ -20,7 +20,7 @@ class ImportCollectionJobTest extends TestCase
         Facades\Taxonomy::make()->handle('collections')->save();
 
         $product = tap(Facades\Entry::make()
-            ->collection('products')
+            ->collection(config('shopify.collection_handle'))
             ->id('product-1')
             ->slug('product-1')
         )->save();

--- a/tests/Unit/ImportSingleProductJobTest.php
+++ b/tests/Unit/ImportSingleProductJobTest.php
@@ -86,7 +86,7 @@ class ImportSingleProductJobTest extends TestCase
             "image": null
         }', true);
 
-        Facades\Collection::make('products')->save();
+        Facades\Collection::make(config('shopify.collection_handle'))->save();
         Facades\Taxonomy::make()->handle('collections')->save();
         Facades\Taxonomy::make()->handle('tags')->save();
         Facades\Taxonomy::make()->handle('type')->save();
@@ -127,7 +127,7 @@ class ImportSingleProductJobTest extends TestCase
 
         Jobs\ImportSingleProductJob::dispatch($data);
 
-        $entry = Facades\Entry::whereCollection('products')->first();
+        $entry = Facades\Entry::whereCollection(config('shopify.collection_handle'))->first();
 
         $this->assertSame($entry->product_id, 1072481042);
         $this->assertSame($entry->get('vendor'), ['burton']);
@@ -212,7 +212,7 @@ class ImportSingleProductJobTest extends TestCase
             "image": null
         }', true);
 
-        Facades\Collection::make('products')->sites(['en', 'fr'])->save();
+        Facades\Collection::make(config('shopify.collection_handle'))->sites(['en', 'fr'])->save();
         Facades\Taxonomy::make()->handle('collections')->save();
         Facades\Taxonomy::make()->handle('tags')->save();
         Facades\Taxonomy::make()->handle('type')->save();
@@ -253,7 +253,7 @@ class ImportSingleProductJobTest extends TestCase
 
         Jobs\ImportSingleProductJob::dispatch($data);
 
-        $entry = Facades\Entry::whereCollection('products')->firstWhere('locale', 'fr');
+        $entry = Facades\Entry::whereCollection(config('shopify.collection_handle'))->firstWhere('locale', 'fr');
 
         $this->assertNotNull($entry);
         $this->assertSame($entry->title, 'Featured items');
@@ -331,7 +331,7 @@ class ImportSingleProductJobTest extends TestCase
             "image": null
         }', true);
 
-        Facades\Collection::make('products')->sites(['en', 'fr'])->dated(true)->save();
+        Facades\Collection::make(config('shopify.collection_handle'))->sites(['en', 'fr'])->dated(true)->save();
         Facades\Taxonomy::make()->handle('collections')->save();
         Facades\Taxonomy::make()->handle('tags')->save();
         Facades\Taxonomy::make()->handle('type')->save();
@@ -365,7 +365,7 @@ class ImportSingleProductJobTest extends TestCase
 
         Jobs\ImportSingleProductJob::dispatch($data);
 
-        $entry = Facades\Entry::whereCollection('products')->first();
+        $entry = Facades\Entry::whereCollection(config('shopify.collection_handle'))->first();
 
         $this->assertNotNull($entry);
         $this->assertSame($entry->get('some_metafield'), 'this is a value');
@@ -443,7 +443,7 @@ class ImportSingleProductJobTest extends TestCase
             "image": null
         }', true);
 
-        Facades\Collection::make('products')->sites(['en', 'fr'])->dated(true)->save();
+        Facades\Collection::make(config('shopify.collection_handle'))->sites(['en', 'fr'])->dated(true)->save();
         Facades\Taxonomy::make()->handle('collections')->save();
         Facades\Taxonomy::make()->handle('tags')->save();
         Facades\Taxonomy::make()->handle('type')->save();
@@ -555,7 +555,7 @@ class ImportSingleProductJobTest extends TestCase
 
         Jobs\ImportSingleProductJob::dispatch($data);
 
-        $entry = Facades\Entry::whereCollection('products')->first();
+        $entry = Facades\Entry::whereCollection(config('shopify.collection_handle'))->first();
 
         $this->assertNotNull($entry);
         $this->assertSame($entry->published(), false);

--- a/tests/Unit/ScopesTest.php
+++ b/tests/Unit/ScopesTest.php
@@ -22,7 +22,7 @@ class ScopesTest extends TestCase
             'slug' => 'obi-wan',
             'product_id' => 1,
         ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 
@@ -66,7 +66,7 @@ class ScopesTest extends TestCase
             'slug' => 'obi-wan',
             'product_id' => 1,
         ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -14,7 +14,7 @@ class ServiceProviderTest extends TestCase
     {
         ServiceProvider::installCollectionsTaxonomiesAssetsAndBlueprints();
 
-        $this->assertNotNull(Facades\Collection::find('products'));
+        $this->assertNotNull(Facades\Collection::find(config('shopify.collection_handle')));
         $this->assertNotNull(Facades\Collection::find('variants'));
         $this->assertNotNull(Facades\Taxonomy::find('collections'));
         $this->assertNotNull(Facades\Taxonomy::find('tags'));

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -38,7 +38,7 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
             'slug' => 'obi-wan',
             'product_id' => 1,
         ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 
@@ -90,7 +90,7 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
             'slug' => 'obi-wan',
             'product_id' => 1,
         ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 
@@ -126,7 +126,7 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
             'slug' => 'obi-wan',
             'product_id' => 1,
         ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 
@@ -191,7 +191,7 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
             'slug' => 'obi-wan',
             'product_id' => 1,
         ])
-            ->collection('products');
+            ->collection(config('shopify.collection_handle'));
 
         $product->save();
 


### PR DESCRIPTION
This PR adds a config key and default for the collection handle that the products should use.

The only area I wasn't sure of was here: https://github.com/johncarter-/statamic-rad-pack-shopify/blob/main/src/Traits/FetchAllProducts.php#L14

But I hope that is the endpoint for the Shopify API to pull from, rather than anything configurable in Statamic.

Hope that's okay.