### PR TITLE
Add product-price hook

### DIFF
--- a/docs/content/en/frontend/tags.md
+++ b/docs/content/en/frontend/tags.md
@@ -53,6 +53,20 @@ From £50.00
 £4.99
 ```
 
+#### product-price hook
+
+This tag provides a [Hook](https://statamic.dev/extending/hooks) to modify the price and currency. For example, if you wanted to format the price using PHP's NumberFormatter:
+
+```php
+\StatamicRadPack\Shopify\Tags\Shopify::hook('product-price', function ($payload, $next) {
+    $formatter = new \NumberFormatter(\Statamic\Facades\Site::current()->locale(), \NumberFormatter::CURRENCY);
+
+    $payload->price = $formatter->formatCurrency((float) $payload->price, 'EUR');
+    
+    return $next($payload);
+});
+```
+
 ## Product Variants
 
 You can interact with the variants in several ways. In the demo theme we output this automatically, but you may want to drill down deeper.

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -2,11 +2,9 @@
 
 namespace StatamicRadPack\Shopify\Tags;
 
-use NumberFormatter;
 use Shopify\Clients\Rest;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Entry;
-use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -65,23 +63,10 @@ class Shopify extends Tags
 
         $price = $pricePluck->sort()->first();
 
-        $payload = [
+        $payload = $this->runHooksWith('product-price', [
             'currency' => config('shopify.currency'),
             'price' => $price,
-        ];
-
-        $this->runHooksWith('shopify-price', $payload);
-
-        // try to use currency
-        if (($currencyCode = config('shopify.currency_code')) && class_exists('NumberFormatter')) {
-            try {
-                $formatter = new \NumberFormatter(Site::current()->locale(), \NumberFormatter::CURRENCY);
-
-                $price = $formatter->formatCurrency((float) $price, $currencyCode);
-
-                $currencyString = ''; // blank this as its included in price
-            } catch (\Throwable $e) { }
-        }
+        ]);
 
         if ($pricePluck->count() > 1 && $this->params->get('show_from') === true) {
             return __('shopify::messages.display_price_from', ['currency' => $payload->currency, 'price' => $payload->price]);

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -2,9 +2,11 @@
 
 namespace StatamicRadPack\Shopify\Tags;
 
+use NumberFormatter;
 use Shopify\Clients\Rest;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -63,10 +65,23 @@ class Shopify extends Tags
 
         $price = $pricePluck->sort()->first();
 
-        $payload = $this->runHooksWith('product-price', [
+        $payload = [
             'currency' => config('shopify.currency'),
             'price' => $price,
-        ]);
+        ];
+
+        $this->runHooksWith('shopify-price', $payload);
+
+        // try to use currency
+        if (($currencyCode = config('shopify.currency_code')) && class_exists('NumberFormatter')) {
+            try {
+                $formatter = new \NumberFormatter(Site::current()->locale(), \NumberFormatter::CURRENCY);
+
+                $price = $formatter->formatCurrency((float) $price, $currencyCode);
+
+                $currencyString = ''; // blank this as its included in price
+            } catch (\Throwable $e) { }
+        }
 
         if ($pricePluck->count() > 1 && $this->params->get('show_from') === true) {
             return __('shopify::messages.display_price_from', ['currency' => $payload->currency, 'price' => $payload->price]);


### PR DESCRIPTION
This PR adds a 'product-price' hook so that the price and currency on the `{{ shopify:product_price }}` tag can be formatted according to your site's requirements.

Closes https://github.com/statamic-rad-pack/shopify/issues/285