### PR TITLE
Allow configuring API version via .env, set fallback in config file, remove outdated fallback in Tag

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -56,7 +56,7 @@ return [
     /**
      * Admin API version - Set this to a fixed value (eg 2023-07) or null to let the library decide
      */
-    'api_version' => null,
+    'api_version' => env('SHOPIFY_API_VERSION', '2025-07'),
 
     /**
      * Admin connection is a private app, defaults to false

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -81,7 +81,7 @@ class Shopify extends Tags
     public function tokens()
     {
         return "<script>
-window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('shopify.url'))."', token: '".config('shopify.storefront_token')."', apiVersion: '".(config('shopify.api_version') ?? '2024-07')."' };
+window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('shopify.url'))."', token: '".config('shopify.storefront_token')."', apiVersion: '".(config('shopify.api_version')."' };
 </script>";
     }
 


### PR DESCRIPTION
Seems more sensible to have the default set in the config file instead of deep in the Antlers Tag — would have saved me an hour or two of debugging GraphQL issues (might also have something to do with me not noticing the `console.warn` lol)