### PR TITLE
Get multisite product collection import working

### DIFF
--- a/src/Jobs/ImportCollectionJob.php
+++ b/src/Jobs/ImportCollectionJob.php
@@ -110,9 +110,9 @@ class ImportCollectionJob implements ShouldQueue
 
                 $query = <<<QUERY
                   query {
-                    translatableResource(resourceId: "gid://shopify/Collection/{$this->collection['id']}") {
+                    translatableResource(resourceId: "gid://shopify/Collection/{$this->collectionId}") {
                       resourceId
-                      translations(locale: "{$site->locale()}") {
+                      translations(locale: "{$site->lang()}") {
                         key
                         value
                       }
@@ -122,12 +122,12 @@ class ImportCollectionJob implements ShouldQueue
 
                 $response = app(Graphql::class)->query(['query' => $query]);
 
-                $translations = Arr::get($response->getDecodedBody(), 'translatableResource.translatableContent', []);
+                $translations = Arr::get($response->getDecodedBody(), 'data.translatableResource.translations', []);
 
                 if ($translations) {
                     $data = collect($translations)->mapWithKeys(fn ($row) => [$row['key'] => $row['value']]);
 
-                    $term->dataForLocale($site->handle(), $data->filter()->all());
+                    $term->in($site->handle())->data($data->filter()->all());
                 }
             });
         }


### PR DESCRIPTION
Importing product collections into a multisite setup is currently failing for a number of reasons.

This is an attempt to solve this by:

### Use the short collection id instead of the full id

Previously, the collection queried was duplicated, so `gid://shopify/Collection/123445gid://shopify/Collection/12345`. This should just be `gid://shopify/Collection/12345`

### Use the lang of the site as query param

Previously, the whole locale was used (`en_US`), which Shopify doesn't return translations for. Short `en` seems to work.

### Adjust data path

The correct path through the response seems to be `data.translatableResource.translations`, not `translatableResource.translatableContent`. This one might also be due to API schema changes on the Storefront end of things. Happy to add a conditional to keep backwards compatibility.

### Assume a LocalizedTerm

For some reason, the term would always already be a LocalizedTerm instance, which doesn't have a `dataForLocale` method. Switching to `$term->in($local)` seems to work better.