### PR TITLE
Adjust CP nav to work with customized taxonomy handles and names

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -94,7 +94,7 @@ class ServiceProvider extends AddonServiceProvider
         Facades\CP\Nav::extend(function ($nav) use ($shopifySvg) {
             $collections = [
                 config('shopify.collection_handle', 'products'),
-                'variants'
+                'variants',
             ];
             $taxonomies = [
                 config('shopify.taxonomies.collections'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -92,13 +92,26 @@ class ServiceProvider extends AddonServiceProvider
         $shopifySvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 109.5 124.5"><path fill="currentColor" d="M74.7 14.8s-1.4.4-3.7 1.1c-.4-1.3-1-2.8-1.8-4.4-2.6-5-6.5-7.7-11.1-7.7-.3 0-.6 0-1 .1-.1-.2-.3-.3-.4-.5-2-2.2-4.6-3.2-7.7-3.1-6 .2-12 4.5-16.8 12.2-3.4 5.4-6 12.2-6.7 17.5-6.9 2.1-11.7 3.6-11.8 3.7-3.5 1.1-3.6 1.2-4 4.5-.6 2.5-9.7 73-9.7 73l75.6 13.1V14.6c-.4.1-.7.1-.9.2zm-17.5 5.4c-4 1.2-8.4 2.6-12.7 3.9 1.2-4.7 3.6-9.4 6.4-12.5 1.1-1.1 2.6-2.4 4.3-3.2 1.7 3.6 2.1 8.5 2 11.8zM49.1 4.3c1.4 0 2.6.3 3.6.9-1.6.8-3.2 2.1-4.7 3.6-3.8 4.1-6.7 10.5-7.9 16.6-3.6 1.1-7.2 2.2-10.5 3.2 2.1-9.5 10.2-24 19.5-24.3zm-11.7 55c.4 6.4 17.3 7.8 18.3 22.9.7 11.9-6.3 20-16.4 20.6-12.2.8-18.9-6.4-18.9-6.4l2.6-11s6.7 5.1 12.1 4.7c3.5-.2 4.8-3.1 4.7-5.1-.5-8.4-14.3-7.9-15.2-21.7-.8-11.5 6.8-23.2 23.6-24.3 6.5-.4 9.8 1.2 9.8 1.2l-3.8 14.4s-4.3-2-9.4-1.6c-7.4.5-7.5 5.2-7.4 6.3zM61.2 19c0-3-.4-7.3-1.8-10.9 4.6.9 6.8 6 7.8 9.1-1.8.5-3.8 1.1-6 1.8zM78.1 123.9l31.4-7.8S96 24.8 95.9 24.2c-.1-.6-.6-1-1.1-1-.5 0-9.3-.2-9.3-.2s-5.4-5.2-7.4-7.2v108.1z"/></svg>';
 
         Facades\CP\Nav::extend(function ($nav) use ($shopifySvg) {
-            $nav->remove('Content', 'Collections', 'Products');
-            $nav->remove('Content', 'Collections', 'Variants');
-
-            $nav->remove('Content', 'Taxonomies', 'Product Collections');
-            $nav->remove('Content', 'Taxonomies', 'Product Tags');
-            $nav->remove('Content', 'Taxonomies', 'Product Type');
-            $nav->remove('Content', 'Taxonomies', 'Product Vendor');
+            $collections = [
+                config('shopify.collection_handle', 'products'),
+                'variants'
+            ];
+            $taxonomies = [
+                config('shopify.taxonomies.collections'),
+                config('shopify.taxonomies.tags'),
+                config('shopify.taxonomies.type'),
+                config('shopify.taxonomies.vendor'),
+            ];
+            foreach ($collections as $handle) {
+                if ($collection = Facades\Collection::find($handle)) {
+                    $nav->remove('Content', 'Collections', $collection->title());
+                }
+            }
+            foreach ($taxonomies as $handle) {
+                if ($taxonomy = Facades\Taxonomy::find($handle)) {
+                    $nav->remove('Content', 'Taxonomies', $taxonomy->title());
+                }
+            }
 
             $user = Facades\User::current();
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -124,19 +124,19 @@ class ServiceProvider extends AddonServiceProvider
                             ->can('view', Facades\Collection::find(config('shopify.collection_handle', 'products'))),
 
                         $nav->create(__('Collections'))
-                            ->route('taxonomies.show', 'collections')
+                            ->route('taxonomies.show', config('shopify.taxonomies.collections'))
                             ->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.collections'))),
 
                         $nav->create(__('Tags'))
-                            ->route('taxonomies.show', 'tags')
+                            ->route('taxonomies.show', config('shopify.taxonomies.tags'))
                             ->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.tags'))),
 
                         $nav->create(__('Product Types'))
-                            ->route('taxonomies.show', 'type')
+                            ->route('taxonomies.show', config('shopify.taxonomies.type'))
                             ->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.type'))),
 
                         $nav->create(__('Vendors'))
-                            ->route('taxonomies.show', 'vendor')
+                            ->route('taxonomies.show', config('shopify.taxonomies.vendor'))
                             ->can('view', Facades\Taxonomy::find(config('shopify.taxonomies.vendor'))),
 
                         $nav->create(__('Settings'))


### PR DESCRIPTION
The CP nav currently still uses the default taxonomy handles for building the urls. I'm getting 404s when clicking them. This PR changes it to use the actual handle from the config instead.

Also, when translating or otherwise customizing the titles of collections and taxonomies (e.g. just `Collections` instead of `Product Collections`), it currently won't remove them from the default CP nav before adding it to the Shopify section nav. This PR changes it to use the actual title of each collection to make sure they are removed.