### PR TITLE
Use actual CP url for fetching product list

### DIFF
--- a/resources/js/components/ImportProductButton.vue
+++ b/resources/js/components/ImportProductButton.vue
@@ -43,7 +43,6 @@ export default {
         fetch() {
             axios.get(this.listUrl)
                 .then(res => {
-                    console.log(res)
                     this.products = res.data.products
                 })
         },
@@ -58,7 +57,6 @@ export default {
 
             axios.get(`${this.url}?product=${this.selectedProduct.product_id}`)
                 .then(res => {
-                    console.log(res)
                     this.message = res.data.message
                     this.messageColor = 'text-green'
 

--- a/resources/js/components/ImportProductButton.vue
+++ b/resources/js/components/ImportProductButton.vue
@@ -22,6 +22,7 @@ import axios from "axios";
 export default {
     props: {
         url: String,
+        listUrl: String,
         product: String
     },
 
@@ -40,7 +41,7 @@ export default {
 
     methods: {
         fetch() {
-            axios.get('/cp/shopify/products')
+            axios.get(this.listUrl)
                 .then(res => {
                     console.log(res)
                     this.products = res.data.products

--- a/resources/views/cp/dashboard.blade.php
+++ b/resources/views/cp/dashboard.blade.php
@@ -19,7 +19,7 @@
         <div class="mt-4 card">
             <h2 class="mb-2">Import Single Product</h2>
             <p class="max-w-md mb-4 text-sm">Fetch a single product's data from Shopify. Please note if you have any `overwrite` option set to true in the config product data will be replaced.</p>
-            <shopify-import-product-button url="{{ cp_route('shopify.products.fetch') }}"></shopify-import-product-button>
+            <shopify-import-product-button url="{{ cp_route('shopify.products.fetch') }}" list-url="{{ cp_route('shopify.products') }}"></shopify-import-product-button>
         </div>
 
         <div class="mt-4 card">


### PR DESCRIPTION
The CP route for fetching products is currently hardcoded into the JS, resulting in a 404 when using a customized CP url other than `/cp`. This PR passes the actual URL into the component to support both scenarios.