### PR TITLE
Filter taxonomies before importing

### DIFF
--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -374,6 +374,7 @@ class ImportSingleProductJob implements ShouldQueue
 
         // 'Tag foo, Tag bar' => ['tag-foo' => 'Tag foo', 'tag-bar' => 'Tag bar']
         $tags = collect($tags)
+            ->filter()
             ->mapWithKeys(fn ($tagTitle) => [Str::slug($tagTitle) => $tagTitle])
             ->each(function ($tagTitle, $tagSlug) use ($taxonomyHandle) {
                 $term = Term::query()


### PR DESCRIPTION
Ran into an issue when importing products without vendor or product type. They would import as terms with empty slug and empty title, subsequently leading to exceptions in the CP because of missing route params. Filtering the terms before import seems to work fine to resolve that case.