### PR TITLE
Only display `from` prefix if prices differ

### DIFF
--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -65,7 +65,7 @@ class Shopify extends Tags
 
         $payload = $this->formatPrice($price);
 
-        if ($pricePluck->count() > 1 && $this->params->get('show_from') === true) {
+        if ($pricePluck->unique()->count() > 1 && $this->params->get('show_from') === true) {
             return __('shopify::messages.display_price_from', ['currency' => $payload->currency, 'price' => $payload->price]);
         }
 

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -80,6 +80,9 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
 
         $this->assertEquals('From £9.99', $this->tag('{{ shopify:product_price show_from="true" }}', ['slug' => 'obi-wan']));
 
+        $variant2->set('price', 9.99)->save();
+
+        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price show_from="true" }}', ['slug' => 'obi-wan']));
     }
 
     #[Test]


### PR DESCRIPTION
- Ensure the "From 9.99€" only displays if the prices of variants actually differ from each other
- For two variants of the same price, it will now show just "9.99€"