### PR TITLE
Allow displaying product price if out of stock

### DIFF
--- a/docs/content/en/frontend/tags.md
+++ b/docs/content/en/frontend/tags.md
@@ -33,7 +33,8 @@ Allows you to output your Site URL and Storefront Token to the front end and bin
 {{ shopify:product_price show_from="true" }}
 ```
 
-- `show_from` will display a "From " prefix to the price if there are multiple variants.
+- `show_from`: display a "From " prefix to the price if there are multiple variants.
+- `show_out_of_stock`: show an "Out of Stock" message if the product is out of stock. Defaults to `true`. If set to `false`, it will return the price even if the product is out of stock.
 
 #### Output
 

--- a/docs/content/en/frontend/tags.md
+++ b/docs/content/en/frontend/tags.md
@@ -34,7 +34,6 @@ Allows you to output your Site URL and Storefront Token to the front end and bin
 ```
 
 - `show_from`: display a "From " prefix to the price if there are multiple variants.
-- `show_out_of_stock`: show an "Out of Stock" message if the product is out of stock. Defaults to `true`. If set to `false`, it will return the price even if the product is out of stock.
 
 #### Output
 

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -62,7 +62,7 @@ class Shopify extends Tags
 
         $langKey = match (true) {
             ! $this->isInStock($variants) => 'out_of_stock',
-            $pricePluck->count() > 1 && $this->params->get('show_from') === true => 'display_price_from',
+            $pricePluck->unique()->count() > 1 && $this->params->get('show_from') === true => 'display_price_from',
             default => 'display_price',
         };
 

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -54,7 +54,7 @@ class Shopify extends Tags
         }
 
         // Out of Stock
-        if ($this->params->get('check_stock', true) !== false && ! $this->isInStock($variants)) {
+        if ($this->params->get('show_out_of_stock', true) !== false && ! $this->isInStock($variants)) {
             return __('shopify::messages.out_of_stock');
         }
 

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -281,7 +281,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
             }
         }
 
-        if ($stock === 0 and $deny) {
+        if ($stock <= 0 and $deny) {
             return false;
         }
 

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -54,7 +54,7 @@ class Shopify extends Tags
         }
 
         // Out of Stock
-        if (! $this->isInStock($variants)) {
+        if ($this->params->get('check_stock', true) !== false && ! $this->isInStock($variants)) {
             return __('shopify::messages.out_of_stock');
         }
 

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -65,7 +65,7 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
 
         $this->assertEquals('Out of Stock', $this->tag('{{ shopify:product_price }}', ['slug' => 'obi-wan']));
 
-        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price show_out_of_stock="false" }}', ['slug' => 'obi-wan']));
+        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price }}', ['slug' => 'obi-wan']));
 
         $variant2 = Facades\Entry::make()->data([
             'title' => 'Another T-shirt',

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -65,8 +65,6 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
 
         $this->assertEquals('Out of Stock', $this->tag('{{ shopify:product_price }}', ['slug' => 'obi-wan']));
 
-        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price }}', ['slug' => 'obi-wan']));
-
         $variant2 = Facades\Entry::make()->data([
             'title' => 'Another T-shirt',
             'slug' => 'obi-wan-tshirt-2',

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -65,6 +65,8 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
 
         $this->assertEquals('Out of Stock', $this->tag('{{ shopify:product_price }}', ['slug' => 'obi-wan']));
 
+        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price check_stock="false" }}', ['slug' => 'obi-wan']));
+
         $variant2 = Facades\Entry::make()->data([
             'title' => 'Another T-shirt',
             'slug' => 'obi-wan-tshirt-2',

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -65,7 +65,7 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
 
         $this->assertEquals('Out of Stock', $this->tag('{{ shopify:product_price }}', ['slug' => 'obi-wan']));
 
-        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price check_stock="false" }}', ['slug' => 'obi-wan']));
+        $this->assertEquals('£9.99', $this->tag('{{ shopify:product_price show_out_of_stock="false" }}', ['slug' => 'obi-wan']));
 
         $variant2 = Facades\Entry::make()->data([
             'title' => 'Another T-shirt',


### PR DESCRIPTION
Add an option to render the product price even when out of stock. I've named it `show_out_of_stock` after a similar parameter in another tag. It defaults to `true`, which is the current behavior, so requires explicit setting to `false`. I'm not a big fan of true-by-default booleans, but couldn't think of another name either. Maybe `ignore_stock`...

```twig
{{ shopify:product_price }}
Out of stock

{{ shopify:product_price show_out_of_stock="false" }}
9.99€
```
