### PR TITLE
Count negative inventory values as out of stock

### DIFF
--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -284,7 +284,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
             }
         }
 
-        if ($stock === 0 and $deny) {
+        if ($stock <= 0 and $deny) {
             return false;
         }
 

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -153,6 +153,18 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2024-07' };
         ])->save();
 
         $this->assertEquals('', $this->tag('{{ if {shopify:in_stock} }}Yes{{ /if }}', ['slug' => 'obi-wan']));
+
+        $variant->merge([
+            'inventory_quantity' => -1,
+        ])->save();
+
+        $this->assertEquals('', $this->tag('{{ if {shopify:in_stock} }}Yes{{ /if }}', ['slug' => 'obi-wan']));
+
+        $variant->merge([
+            'inventory_quantity' => null,
+        ])->save();
+
+        $this->assertEquals('', $this->tag('{{ if {shopify:in_stock} }}Yes{{ /if }}', ['slug' => 'obi-wan']));
     }
 
     #[Test]


### PR DESCRIPTION
Ran into a case where the inventory of a product dropped below zero, and only later was set to `deny`. The current check only considers `0` inventory as out of stock. This PR would make it so negative inventory values are also considered out of stock. Added a test for `null` values for good measure.