### PR TITLE
Propagate Shopify translations to entry localizations

### DIFF
--- a/docs/content/en/CMS/multisite.md
+++ b/docs/content/en/CMS/multisite.md
@@ -14,7 +14,7 @@ Ensure your API key has enabled the `read_translations` permission for this feat
 
 You need to enable multi-site on the `Products` collection and `Collections`, `Product Types`, `Tags` and `Vendor` taxonomies. You can do this by editing the configuration and adding the sites you want to enable to the `sites` field.
 
-On the Products collection ensure that `Propogate` is toggled on, and that the `Origin Behaviour` is set to `Use the site the entry was created in`.
+On the Products collection ensure that `Propagate` is toggled on, and that the `Origin Behaviour` is set to `Use the site the entry was created in`.
 
 ## How it works
 

--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -503,7 +503,6 @@ class ImportSingleProductJob implements ShouldQueue
                     $response = app(Graphql::class)->query(['query' => $query]);
 
                     $translations = Arr::get($response->getDecodedBody(), 'data.translatableResource.translations', []);
-                    ray($translations, $response->getDecodedBody());
 
                     if ($translations || $entry->collection()->propagate()) {
                         $localizedEntry = $entry->in($site->handle());

--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -351,7 +351,7 @@ class ImportSingleProductJob implements ShouldQueue
 
                 $translations = Arr::get($response->getDecodedBody(), 'data.translatableResource.translations', []);
 
-                if ($translations) {
+                if ($translations || $entry->collection()->propagate()) {
                     $localizedEntry = $entry->in($site->handle());
 
                     if (! $localizedEntry) {
@@ -503,8 +503,9 @@ class ImportSingleProductJob implements ShouldQueue
                     $response = app(Graphql::class)->query(['query' => $query]);
 
                     $translations = Arr::get($response->getDecodedBody(), 'data.translatableResource.translations', []);
+                    ray($translations, $response->getDecodedBody());
 
-                    if ($translations) {
+                    if ($translations || $entry->collection()->propagate()) {
                         $localizedEntry = $entry->in($site->handle());
 
                         if (! $localizedEntry) {

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -249,18 +249,11 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
             return null;
         }
 
-        return $entries->map(function ($variant) {
-            $values = [];
-            $values['id'] = $variant->id();
-            $values['slug'] = $variant->slug();
-
-            // Map all variant values to data to ensure we are getting everything.
-            foreach ($variant->data() as $key => $value) {
-                $values[$key] = $value;
-            }
-
-            return $values;
-        });
+        return $entries->map(fn ($variant) => [
+            'id' => $variant->id(),
+            'slug' => $variant->slug(),
+            ...$variant->values(),
+        ])->unique('variant_id')->values();
     }
 
     /**


### PR DESCRIPTION
We ran into a few snags syncing translated products and variants into a multisite setup.

- Following the docs, we set the collections to propagate, but localizations are currently only created if the product or variant is actually translated in Shopify. This will lead to unpublished products in non-default locales on the Statamic side of things. Which differs from the default behavior of a Shopify theme, which would show the untranslated product and fall back to the default locale for display. Checking for the propagate flag of the collection and always creating those entries seems to work here.

- When compiling variants data, translated entries currently don't have any price or inventory data, leading to exceptions when calculating in-stock status and displaying prices. Switching from `data()` to `values()` and filtering down to unique variant ids seems to work here.