### PR TITLE
Update slug when product handle updates

### DIFF
--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -198,9 +198,11 @@ class ImportSingleProductJob implements ShouldQueue
         if (! $entry) {
             $entry = Entry::make()
                 ->collection(config('shopify.collection_handle', 'products'))
-                ->locale(Site::default()->handle())
-                ->slug($this->data['handle']);
+                ->locale(Site::default()->handle());
         }
+
+        // Update slug in case it has changed
+        $entry->slug($this->data['handle']);
 
         // Import Variant
         $this->importVariants($this->data['variants'], $this->data['handle']);
@@ -357,6 +359,9 @@ class ImportSingleProductJob implements ShouldQueue
                     if (! $localizedEntry) {
                         $localizedEntry = $entry->makeLocalization($site);
                     }
+
+                    // All localizations should have the same handle for correct connections to variants
+                    $localizedEntry->slug($entry->slug());
 
                     $data = collect($translations)->mapWithKeys(fn ($row) => [$row['key'] == 'body_html' ? 'content' : $row['key'] => $row['value']]);
 


### PR DESCRIPTION
Updating a product handle in Shopify and resyncing into Statamic currently leads to disconnected variants — the products keep their old slug while the variants are updated to reference the new one. This proposed solution updates the entry slug to always match the Shopify handle. Requires the `slug` field in the control panel to be set to read-only or hidden. That's how we handle it at least.

Alternatively, one could allow updates to entry slugs inside Statamic, which would require a different change instead. This would/could tie into the `overwrite` setting, which would make overwriting the slug optional/configurable.

```diff
// Import Variant
- $this->importVariants($this->data['variants'], $this->data['handle']);
+ $this->importVariants($this->data['variants'], $entry->slug());
```