### PR TITLE
Add check for if status context exists on custormerOrders function

### DIFF
--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -488,7 +488,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
         }
 
         $status = '';
-        if (! in_array($this->context->get('status'), ['not_closed', 'open', 'closed', 'cancelled'])) {
+        if ($this->context->get('status') && ! in_array($this->context->get('status'), ['not_closed', 'open', 'closed', 'cancelled'])) {
             $status = ' AND status = '.$this->context->get('status');
         }
 


### PR DESCRIPTION
Currently 
```
if (! in_array($this->context->get('status'), ['not_closed', 'open', 'closed', 'cancelled'])) { 
```
is always true and adds ' AND status = ' to the query even if no context is defined.

This fix checks if the status context exists and then adds the status if the ! in_array check is true.