### PR TITLE
Add name, status and status url back to query nodes

### DIFF
--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -66,7 +66,7 @@ class Shopify extends Tags
             default => 'display_price',
         };
 
-        return __('shopify::messages.' . $langKey, ['currency' => $payload->currency, 'price' => $payload->price]);
+        return __('shopify::messages.'.$langKey, ['currency' => $payload->currency, 'price' => $payload->price]);
     }
 
     /**

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -283,7 +283,6 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2025-04' };
         $this->assertEquals('abc', $this->tag('{{ shopify:variants variant_id:is="abc" }}{{ variant_id }}{{ /shopify:variants }}', ['slug' => 'obi-wan']));
     }
 
-
     #[Test]
     public function runs_hooks_on_variant_price()
     {


### PR DESCRIPTION
These were previously available variables when querying orders but seems to have been removed when we switched to graphQL