### PR TITLE
Security: bump shopify/shopify-api to ^6.1.1 for Statamic v4/v5 line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "pixelfear/composer-dist-plugin": "^0.1",
-        "shopify/shopify-api": "^5.1",
+        "shopify/shopify-api": "^6.1.1",
         "statamic/cms": "^4.56 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary                                                                                                                                                                                       
                                                                                                                                                                                                   
  - Bumps `shopify/shopify-api` from `^5.1` to `^6.1.1` to resolve a security vulnerability fixed in v6.x                                                                                          
  - Keeps full compatibility with `statamic/cms: ^4.56 || ^5.0`                                                                                                                                    
  - No breaking changes — the only API change in shopify-api v6 is that `apiVersion` is required, which this package already had                                                             
                                                                                                                                                                                                   
  ## Why not just upgrade to v7.x of this addon?                                                                                                                                                   
                                                                                                                                                                                                   
  v7.x requires Statamic v6. Projects still on Statamic v4/v5 are exposed to the vulnerability with no upgrade path. This backport provides the security fix while maintaining Statamic v4/v5 compatibility.                                                                                                                                                                                 
                                                                                                                                                                                                   
  ## Testing                                                                                                                                                                                       
   - `composer audit` — no vulnerabilities                                                                                                                                                          
  - App boots, all 22 shopify routes registered, config loads correctly                                                                                                                          
  - Tested on a real Statamic v5 + Laravel v12 project
    - in compose.json
    ```json
    "repositories": [
    {
        "type": "vcs",
        "url": "https://github.com/kreatifIT/statamic-rad-pack-shopify.git"
    }]

updated version in composer require subset -> "statamic-rad-pack/shopify": "^6.6.0", and after that composer update statamic-rad-pack/shopify shopify/shopify-api -W --prefer-source.
  