### PR TITLE
Track and store last received on webhook table

### DIFF
--- a/resources/js/components/WebhookStatus.vue
+++ b/resources/js/components/WebhookStatus.vue
@@ -10,6 +10,7 @@
                     <ui-table-column>Topic</ui-table-column>
                     <ui-table-column>Callback URL</ui-table-column>
                     <ui-table-column>Status</ui-table-column>
+                    <ui-table-column>Last received</ui-table-column>
                 </ui-table-columns>
                 <ui-table-rows>
                     <ui-table-row v-for="webhook in webhooks" :key="webhook.id">
@@ -19,13 +20,15 @@
                             <ui-badge v-if="webhook.expected" color="green" icon="check" text="Registered" />
                             <ui-badge v-else color="amber" icon="warning" text="Unknown URL" />
                         </ui-table-cell>
+                        <ui-table-cell class="text-xs">{{ formatLastReceived(webhook.last_received_at) }}</ui-table-cell>
                     </ui-table-row>
                     <ui-table-row v-for="topic in missingTopics" :key="topic">
                         <ui-table-cell class="font-mono text-xs">{{ topic }}</ui-table-cell>
-                        <ui-table-cell class="font-mono text-xs text-gray-400">{{ expected[topic] }}</ui-table-cell>
+                        <ui-table-cell class="font-mono text-xs">{{ expected[topic] }}</ui-table-cell>
                         <ui-table-cell>
                             <ui-badge color="red" icon="warning-diamond" text="Not registered" />
                         </ui-table-cell>
+                        <ui-table-cell class="text-xs">—</ui-table-cell>
                     </ui-table-row>
                 </ui-table-rows>
             </ui-table>
@@ -64,6 +67,13 @@ export default {
                 .map(w => w.topic);
 
             return Object.keys(this.expected).filter(t => !registeredTopics.includes(t));
+        },
+    },
+
+    methods: {
+        formatLastReceived(timestamp) {
+            if (!timestamp) return 'Never';
+            return new Date(timestamp).toLocaleString();
         },
     },
 

--- a/src/Http/Controllers/CP/WebhooksStatusController.php
+++ b/src/Http/Controllers/CP/WebhooksStatusController.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Shopify\Http\Controllers\CP;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Shopify\Clients\Graphql;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Support\Arr;
@@ -39,12 +40,22 @@ class WebhooksStatusController extends CpController
         $webhooks = collect($registered)->map(fn ($webhook) => array_merge($webhook, [
             'expected' => isset($expected[$webhook['topic']])
                 && $webhook['callbackUrl'] === $expected[$webhook['topic']],
+            'last_received_at' => $this->getLastReceivedAt($webhook['topic'], $storeHandle),
         ]))->all();
 
         return response()->json([
             'webhooks' => $webhooks,
             'expected' => $expected,
         ]);
+    }
+
+    private function getLastReceivedAt(string $topic, ?string $storeHandle): ?string
+    {
+        $cacheKey = $storeHandle
+            ? "shopify::webhook_last_received::{$storeHandle}::{$topic}"
+            : "shopify::webhook_last_received::{$topic}";
+
+        return Cache::get($cacheKey);
     }
 
     private function fetchWebhooks(Graphql $graphql): array

--- a/src/Http/Middleware/VerifyShopifyHeaders.php
+++ b/src/Http/Middleware/VerifyShopifyHeaders.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Shopify\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use StatamicRadPack\Shopify\Support\StoreConfig;
 
 class VerifyShopifyHeaders
@@ -34,7 +35,27 @@ class VerifyShopifyHeaders
             return response()->json(['error' => true], 403);
         }
 
+        $this->recordLastReceived($request);
+
         return $next($request);
+    }
+
+    protected function recordLastReceived(Request $request): void
+    {
+        $rawTopic = $request->header('X-Shopify-Topic');
+
+        if (! $rawTopic) {
+            return;
+        }
+
+        $topic = str_replace('/', '_', strtoupper($rawTopic));
+        $storeHandle = $request->attributes->get('shopify_store_handle');
+
+        $cacheKey = $storeHandle
+            ? "shopify::webhook_last_received::{$storeHandle}::{$topic}"
+            : "shopify::webhook_last_received::{$topic}";
+
+        Cache::forever($cacheKey, now()->toIso8601String());
     }
 
     /**

--- a/tests/Unit/WebhookLastReceivedTest.php
+++ b/tests/Unit/WebhookLastReceivedTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Tests\Unit;
+
+use Illuminate\Support\Facades\Cache;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Shopify\Clients\Graphql;
+use Shopify\Clients\HttpResponse;
+use Statamic\Facades\User;
+use StatamicRadPack\Shopify\Tests\TestCase;
+
+class WebhookLastReceivedTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('shopify.ignore_webhook_integrity_check', true);
+    }
+
+    private function actingAsSuperUser()
+    {
+        $user = User::make()->email('admin@example.com')->makeSuper()->save();
+
+        return $this->actingAs($user);
+    }
+
+    private function shopifyWebhooksResponse(array $nodes = []): string
+    {
+        return json_encode([
+            'data' => [
+                'webhookSubscriptions' => [
+                    'nodes' => $nodes,
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function records_last_received_timestamp_on_webhook_request()
+    {
+        Cache::flush();
+
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock->shouldReceive('query')->andReturn(new HttpResponse(status: 200, body: '{}'));
+        });
+
+        $this->postJson('/!/shopify/webhook/product/create', ['id' => 1], [
+            'X-Shopify-Topic' => 'products/create',
+        ]);
+
+        $this->assertNotNull(Cache::get('shopify::webhook_last_received::PRODUCTS_CREATE'));
+    }
+
+    #[Test]
+    public function normalises_topic_header_to_enum_format()
+    {
+        Cache::flush();
+
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock->shouldReceive('query')->andReturn(new HttpResponse(status: 200, body: '{}'));
+        });
+
+        $this->postJson('/!/shopify/webhook/collection/update', ['id' => 1], [
+            'X-Shopify-Topic' => 'collections/update',
+        ]);
+
+        $this->assertNotNull(Cache::get('shopify::webhook_last_received::COLLECTIONS_UPDATE'));
+    }
+
+    #[Test]
+    public function does_not_record_timestamp_when_verification_fails()
+    {
+        Cache::flush();
+        config()->set('shopify.ignore_webhook_integrity_check', false);
+        config()->set('shopify.webhook_secret', 'secret');
+
+        $this->postJson('/!/shopify/webhook/product/create', ['id' => 1], [
+            'X-Shopify-Topic' => 'products/create',
+            'X-Shopify-Hmac-Sha256' => 'invalid',
+        ]);
+
+        $this->assertNull(Cache::get('shopify::webhook_last_received::PRODUCTS_CREATE'));
+    }
+
+    #[Test]
+    public function records_timestamp_per_store_in_multi_store_mode()
+    {
+        Cache::flush();
+
+        config(['shopify.multi_store' => [
+            'enabled' => true,
+            'mode' => 'unified',
+            'stores' => [
+                'uk' => [
+                    'url' => 'uk.myshopify.com',
+                    'webhook_secret' => 'secret',
+                ],
+            ],
+        ]]);
+
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock->shouldReceive('query')->andReturn(new HttpResponse(status: 200, body: '{}'));
+        });
+
+        $this->postJson('/!/shopify/webhook/product/update', ['id' => 1], [
+            'X-Shopify-Topic' => 'products/update',
+            'X-Shopify-Shop-Domain' => 'uk.myshopify.com',
+        ]);
+
+        $this->assertNotNull(Cache::get('shopify::webhook_last_received::uk::PRODUCTS_UPDATE'));
+        $this->assertNull(Cache::get('shopify::webhook_last_received::PRODUCTS_UPDATE'));
+    }
+
+    #[Test]
+    public function status_controller_includes_last_received_at_for_each_webhook()
+    {
+        $callbackUrl = route('statamic.shopify.webhook.product.create', [], true);
+
+        Cache::forever('shopify::webhook_last_received::PRODUCTS_CREATE', '2025-06-01T12:00:00+00:00');
+
+        $this->mock(Graphql::class, function (MockInterface $mock) use ($callbackUrl) {
+            $mock->shouldReceive('query')
+                ->once()
+                ->andReturn(new HttpResponse(status: 200, body: $this->shopifyWebhooksResponse([
+                    [
+                        'id' => 'gid://shopify/WebhookSubscription/1',
+                        'topic' => 'PRODUCTS_CREATE',
+                        'endpoint' => ['callbackUrl' => $callbackUrl],
+                        'createdAt' => '2025-01-01T00:00:00Z',
+                    ],
+                ])));
+        });
+
+        $response = $this->actingAsSuperUser()
+            ->getJson(cp_route('shopify.webhooks.status'));
+
+        $response->assertOk();
+        $this->assertSame('2025-06-01T12:00:00+00:00', $response->json('webhooks.0.last_received_at'));
+    }
+
+    #[Test]
+    public function status_controller_returns_null_last_received_at_when_never_fired()
+    {
+        Cache::flush();
+
+        $callbackUrl = route('statamic.shopify.webhook.product.create', [], true);
+
+        $this->mock(Graphql::class, function (MockInterface $mock) use ($callbackUrl) {
+            $mock->shouldReceive('query')
+                ->once()
+                ->andReturn(new HttpResponse(status: 200, body: $this->shopifyWebhooksResponse([
+                    [
+                        'id' => 'gid://shopify/WebhookSubscription/1',
+                        'topic' => 'PRODUCTS_CREATE',
+                        'endpoint' => ['callbackUrl' => $callbackUrl],
+                        'createdAt' => '2025-01-01T00:00:00Z',
+                    ],
+                ])));
+        });
+
+        $response = $this->actingAsSuperUser()
+            ->getJson(cp_route('shopify.webhooks.status'));
+
+        $response->assertOk();
+        $this->assertNull($response->json('webhooks.0.last_received_at'));
+    }
+
+    #[Test]
+    public function status_controller_uses_store_scoped_cache_key_in_multi_store_mode()
+    {
+        Cache::flush();
+
+        config(['shopify.multi_store' => [
+            'enabled' => true,
+            'mode' => 'unified',
+            'stores' => [
+                'uk' => ['url' => 'uk.myshopify.com', 'admin_token' => 'tok'],
+            ],
+        ]]);
+
+        $callbackUrl = route('statamic.shopify.webhook.product.create', [], true);
+
+        Cache::forever('shopify::webhook_last_received::uk::PRODUCTS_CREATE', '2025-06-01T12:00:00+00:00');
+
+        $this->app->instance('shopify.graphql.uk', tap($this->mock(Graphql::class), function (MockInterface $mock) use ($callbackUrl) {
+            $mock->shouldReceive('query')
+                ->once()
+                ->andReturn(new HttpResponse(status: 200, body: $this->shopifyWebhooksResponse([
+                    [
+                        'id' => 'gid://shopify/WebhookSubscription/1',
+                        'topic' => 'PRODUCTS_CREATE',
+                        'endpoint' => ['callbackUrl' => $callbackUrl],
+                        'createdAt' => '2025-01-01T00:00:00Z',
+                    ],
+                ])));
+        }));
+
+        $response = $this->actingAsSuperUser()
+            ->getJson(cp_route('shopify.webhooks.status').'?store=uk');
+
+        $response->assertOk();
+        $this->assertSame('2025-06-01T12:00:00+00:00', $response->json('webhooks.0.last_received_at'));
+    }
+}


### PR DESCRIPTION
This PR adds last received to the web hook status table:

<img width="874" height="646" alt="CleanShot 2026-03-13 at 11 03 00@2x" src="https://github.com/user-attachments/assets/29115d21-7674-416e-b1d3-4cebbcc63f2e" />
