### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.4]
-        laravel: [12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         statamic: [^6.0]
     name: P${{ matrix.php }} - S${{ matrix.statamic }} - L${{ matrix.laravel }} - ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         "statamic/cms": "^6.0"
     },
     "require-dev": {
-        "jasonmccreary/laravel-test-assertions": "^2.0",
+        "jasonmccreary/laravel-test-assertions": "^2.9",
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^10.0.2",
-        "phpunit/phpunit": "^11.0",
+        "orchestra/testbench": "^10.0.2 || ^11.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
         "spatie/laravel-ray": "*"
     },
     "autoload": {


### PR DESCRIPTION
This pull request adds Laravel 13 support to the Shopify addon. This PR also adds PHP 8.5 to the testing matrix.