### PR TITLE
Add product import hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Shopify data maps to Statamic content:
 4. The `SavesImagesAndMetafields` trait handles image downloading and metafield parsing (delegated to the class in `config('shopify.metafields_parser')`). Alt text from Shopify is saved/updated on the Statamic asset's `alt` field.
 5. In multisite setups, the job also fetches Shopify translations for each locale
 6. All GraphQL calls in the import pipeline go through `ThrottlesShopifyRequests::queryWithThrottle()`, which inspects `extensions.cost.throttleStatus` and sleeps if the available query budget drops below 500 points.
+7. `ImportSingleProductJob` uses Statamic's `Hookable` trait (same mechanism as the `product-price` tag hook) to expose two hooks: `import-product-query` (modify the GraphQL query before it's sent) and `import-product-data` (modify the data array before it's merged onto the entry). See `docs/content/en/CMS/importing-data.md`.
 
 ### Webhooks
 

--- a/docs/content/en/CMS/importing-data.md
+++ b/docs/content/en/CMS/importing-data.md
@@ -147,3 +147,47 @@ $bard = (new StatamicRadPack\Shopify\Support\RichTextConverter)->convert($metafi
 
 
 ```
+
+## Hooks
+
+`ImportSingleProductJob` provides two [Hooks](https://statamic.dev/extending/hooks) so you can tap into the import pipeline without overriding the job.
+
+#### import-product-query hook
+
+Runs just before the product GraphQL query is sent to Shopify. Use it to add or change fields on the query, e.g. to pull in additional data.
+
+```php
+\StatamicRadPack\Shopify\Jobs\ImportSingleProductJob::hook('import-product-query', function ($payload, $next) {
+    // $payload->query        — the GraphQL query string about to be sent
+    // $payload->productId    — the Shopify product ID being imported
+    // $payload->storeHandle  — the store handle in multi-store mode, otherwise null
+
+    $payload->query = str_replace('descriptionHtml', 'descriptionHtml seo { title }', $payload->query);
+
+    return $next($payload);
+});
+```
+
+#### import-product-data hook
+
+Runs just before the imported data is merged onto the Statamic entry. Use it to modify, add, or remove fields before they're saved.
+
+```php
+\StatamicRadPack\Shopify\Jobs\ImportSingleProductJob::hook('import-product-data', function ($payload, $next) {
+    // $payload->data        — the array of data about to be merged onto the entry
+    // $payload->entry       — the Statamic entry (existing or newly made) being imported into
+    // $payload->product     — the raw product data returned by Shopify
+
+    $data = $payload->data;
+    $data['title'] = strtoupper($data['title']);
+    $payload->data = $data;
+
+    return $next($payload);
+});
+```
+
+<alert type="info">
+
+  Because `$payload->data` is an array exposed through a magic property, you can't modify it in place (e.g. `$payload->data['title'] = '...'`). Assign it to a local variable, change it, then assign it back to `$payload->data` as shown above.
+
+</alert>

--- a/src/Jobs/ImportSingleProductJob.php
+++ b/src/Jobs/ImportSingleProductJob.php
@@ -3,7 +3,6 @@
 namespace StatamicRadPack\Shopify\Jobs;
 
 use Carbon\Carbon;
-use Throwable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -15,14 +14,17 @@ use Statamic\Facades\Site;
 use Statamic\Facades\Term;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Support\Traits\Hookable;
 use StatamicRadPack\Shopify\Events\ProductImportFailed;
 use StatamicRadPack\Shopify\Support\StoreConfig;
 use StatamicRadPack\Shopify\Traits\SavesImagesAndMetafields;
 use StatamicRadPack\Shopify\Traits\ThrottlesShopifyRequests;
+use Throwable;
 
 class ImportSingleProductJob implements ShouldQueue
 {
     use Dispatchable;
+    use Hookable;
     use InteractsWithQueue;
     use Queueable;
     use SavesImagesAndMetafields;
@@ -114,6 +116,12 @@ class ImportSingleProductJob implements ShouldQueue
           }
         }
         QUERY;
+
+        $query = $this->runHooksWith('import-product-query', [
+            'query' => $query,
+            'productId' => $this->productId,
+            'storeHandle' => $this->storeHandle,
+        ])->query;
 
         $response = $this->queryWithThrottle($graphql, ['query' => $query]);
 
@@ -212,6 +220,12 @@ class ImportSingleProductJob implements ShouldQueue
 
             $data = $this->updatePurchaseHistory($data, $qty);
         }
+
+        $data = $this->runHooksWith('import-product-data', [
+            'data' => $data,
+            'entry' => $entry,
+            'product' => $this->data,
+        ])->data;
 
         $entry->merge($data);
 

--- a/tests/Unit/ImportSingleProductJobTest.php
+++ b/tests/Unit/ImportSingleProductJobTest.php
@@ -506,6 +506,93 @@ class ImportSingleProductJobTest extends TestCase
         $this->assertSame('CONTINUE', $variant->get('inventory_policy'));
     }
 
+    #[Test]
+    public function import_product_query_hook_can_modify_the_query()
+    {
+        Facades\Collection::make(config('shopify.collection_handle', 'products'))->save();
+        Facades\Taxonomy::make()->handle('collections')->save();
+        Facades\Taxonomy::make()->handle('tags')->save();
+        Facades\Taxonomy::make()->handle('type')->save();
+        Facades\Taxonomy::make()->handle('vendor')->save();
+
+        $seenProductId = null;
+        $seenStoreHandle = 'not-set';
+
+        Jobs\ImportSingleProductJob::hook('import-product-query', function ($payload, $next) use (&$seenProductId, &$seenStoreHandle) {
+            $seenProductId = $payload->productId;
+            $seenStoreHandle = $payload->storeHandle;
+
+            $payload->query = str_replace('descriptionHtml', 'descriptionHtml # hook-applied', $payload->query);
+
+            return $next($payload);
+        });
+
+        $receivedQuery = null;
+
+        $this->mock(Graphql::class, function (MockInterface $mock) use (&$receivedQuery) {
+            $mock
+                ->shouldReceive('query')
+                ->withArgs(function ($query) use (&$receivedQuery) {
+                    if (str_contains($query['query'], 'product(id')) {
+                        $receivedQuery = $query['query'];
+                    }
+
+                    return true;
+                })
+                ->andReturn(new HttpResponse(
+                    status: 200,
+                    body: $this->getProductJson()
+                ));
+        });
+
+        Jobs\ImportSingleProductJob::dispatch(1);
+
+        $this->assertSame(1, $seenProductId);
+        $this->assertNull($seenStoreHandle);
+        $this->assertStringContainsString('# hook-applied', $receivedQuery);
+    }
+
+    #[Test]
+    public function import_product_data_hook_can_modify_data_before_it_is_merged()
+    {
+        Facades\Collection::make(config('shopify.collection_handle', 'products'))->save();
+        Facades\Taxonomy::make()->handle('collections')->save();
+        Facades\Taxonomy::make()->handle('tags')->save();
+        Facades\Taxonomy::make()->handle('type')->save();
+        Facades\Taxonomy::make()->handle('vendor')->save();
+
+        $seenEntry = null;
+        $seenProduct = null;
+
+        Jobs\ImportSingleProductJob::hook('import-product-data', function ($payload, $next) use (&$seenEntry, &$seenProduct) {
+            $seenEntry = $payload->entry;
+            $seenProduct = $payload->product;
+
+            $data = $payload->data;
+            $data['title'] = 'Hooked title';
+            $payload->data = $data;
+
+            return $next($payload);
+        });
+
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('query')
+                ->andReturn(new HttpResponse(
+                    status: 200,
+                    body: $this->getProductJson()
+                ));
+        });
+
+        Jobs\ImportSingleProductJob::dispatch(1);
+
+        $entry = Facades\Entry::whereCollection(config('shopify.collection_handle', 'products'))->first();
+
+        $this->assertSame('Hooked title', $entry->title);
+        $this->assertInstanceOf(\Statamic\Contracts\Entries\Entry::class, $seenEntry);
+        $this->assertSame('108828309', $seenProduct['id']);
+    }
+
     private function getProductJson(): string
     {
         return '{


### PR DESCRIPTION
This PR adds two hooks to the product import lifecycle:

    - import-product-query — fires right before the GraphQL query is sent, payload has query, productId, storeHandle.                                                         
    - import-product-data — fires right before $entry->merge($data), payload has data, entry, product (raw Shopify data).

Closes #348 