### PR TITLE
docs: note JS prerequisites where the scripts are published

### DIFF
--- a/docs/content/2.installation/1.setup.md
+++ b/docs/content/2.installation/1.setup.md
@@ -133,6 +133,21 @@ Publishes the JavaScript files which have been created to speed up your integrat
 php artisan vendor:publish --tag="shopify-scripts"
 ```
 
+Two things are required before the published JavaScript will work:
+
+```bash
+npm install @shopify/storefront-api-client
+```
+
+And `{{ shopify:tokens }}` has to be output **before** your bundle is loaded — in the
+`<head>`, above the `@vite`/`{{ vite }}` tag. `client.js` reads `window.shopifyConfig.url`
+at import time rather than on first use, so if the tag comes later the module throws
+`Cannot read properties of undefined (reading 'url')` while your bundle is still
+initialising. Anything registered after that point — including the `shopifyProduct` Alpine
+component — is silently skipped, with no error in the page itself.
+
+See [Storefront API](/frontend/storefront-api) for the full JavaScript setup.
+
 #### Theme Files
 
 You can publish the starter theme files if you want to get started quickly or see how the JavaScript integrates.


### PR DESCRIPTION
### What

Adds the two prerequisites for the published JavaScript to `2.installation/1.setup.md`, right under the `vendor:publish --tag="shopify-scripts"` command.

### Why

Both are already covered on the Storefront API page, but the installation guide publishes the scripts without mentioning them — following it top to bottom leaves you with a non-working integration and no obvious reason why.

The ordering requirement for `{{ shopify:tokens }}` is not documented anywhere. `client.js` reads `window.shopifyConfig.url` at import time rather than on first use, so a tag placed after the bundle throws:

```
TypeError: Cannot read properties of undefined (reading 'url')
```

That error aborts the bundle while it is still initialising, and everything registered after it is skipped — in our case `createData(Alpine)`, so `shopifyProduct` was never registered. The page renders, the markup is correct, `x-data` is on the element, and Alpine just does nothing. There is no error visible in the page itself.

It cost us most of a day to find, across two separate symptoms that both looked like layout bugs.

### Context

Found while building a headless storefront on v7.8.5. Same project as #354 and #356.