### PR TITLE
fix: assign the normalised options object to this.options

### DIFF
--- a/resources/js/shopify/alpine.js
+++ b/resources/js/shopify/alpine.js
@@ -100,6 +100,7 @@ const createData = (Alpine) => {
 
             if (! options) {
                 options = {};
+                this.options = options;
             }
 
             this.selectedVariant = variants[0];


### PR DESCRIPTION
### What

`Alpine.data('shopifyProduct')` guards against a missing `options` argument, but the guard only reassigns the local parameter. The public `options` property keeps the original `null`:

```js
Alpine.data('shopifyProduct', (options, variants) => ({
    options: options,        // ← property is set to null here
    // ...
    init() {
        // ...
        if (! options) {
            options = {};    // ← only the closure variable is fixed
        }
    }
```

From that point on the property and the closure disagree.

### Why it matters

Every internal method reads the closure, so the addon itself never trips over it:

| Line | Method |
|---|---|
| 108 | `init()` |
| 116, 122 | `allOptionsSelected()` |
| 184 | `variantExistsAndIsInStock()` |

What breaks is only what the template sees — and `options` is exposed as a property precisely so templates can use it. The documented usage is:

```html
<template x-for="(option, index) in options">
```

On a product without options, that template receives `null` instead of `{}`. Iterating is harmless, but anything that inspects the object throws:

```
Uncaught TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
```

### Reproduce

1. A product with a single variant and no options (Shopify reports `Default Title`).
2. In the product template, read the property, e.g. `x-init="Object.keys(options)"`.
3. The expression throws; the same call against the closure inside the component succeeds.

### Fix

```diff
         if (! options) {
             options = {};
+            this.options = options;
         }
```

Assigning inside the guard keeps both in sync without touching the happy path.

### Notes

Found while building a headless storefront on v7.8.5 — same project as #354, #356 and #359.

No test added: the file has no JS test setup, and the change is a one-line assignment inside an existing guard. Happy to add one if you'd like a harness for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
