### PR TITLE
Various security hardening fixes

### DIFF
--- a/docs/content/2.installation/3.upgrading.md
+++ b/docs/content/2.installation/3.upgrading.md
@@ -9,6 +9,10 @@ description: ''
 
 The `/!/shopify/address` create, update and delete endpoints now require an authenticated Statamic user and always act on that user's linked Shopify customer. A `customer_id` supplied in the request (or via `{{ shopify:address_form customer_id="..." }}`) is ignored. `redirect` / `error_redirect` values that point off-site are also ignored. If your storefront relied on calling these endpoints for a guest or for an arbitrary customer, that will no longer work.
 
+**Customer tag scoping**
+
+The `customer_id` parameter on `{{ shopify:customer }}`, `{{ shopify:customer:addresses }}` and `{{ shopify:customer:orders }}` is no longer supported. These tags now always return data for the logged in user. Previously a `customer_id` could be passed to fetch any customer, which meant a template rendering it from request input would expose other customers' data.
+
 ## Upgrading from 5.x to 6.x
 
 This release contains a number of breaking changes to the integration code and data. After updating you should re-sync all products to ensure the data is in the most up to date format.

--- a/docs/content/2.installation/3.upgrading.md
+++ b/docs/content/2.installation/3.upgrading.md
@@ -3,6 +3,12 @@ title: Upgrading
 description: ''
 ---
 
+## Upgrading to 7.11.0 
+
+**Address endpoint behaviour change**
+
+The `/!/shopify/address` create, update and delete endpoints now require an authenticated Statamic user and always act on that user's linked Shopify customer. A `customer_id` supplied in the request (or via `{{ shopify:address_form customer_id="..." }}`) is ignored. `redirect` / `error_redirect` values that point off-site are also ignored. If your storefront relied on calling these endpoints for a guest or for an arbitrary customer, that will no longer work.
+
 ## Upgrading from 5.x to 6.x
 
 This release contains a number of breaking changes to the integration code and data. After updating you should re-sync all products to ensure the data is in the most up to date format.

--- a/docs/content/3.cms/4.actions.md
+++ b/docs/content/3.cms/4.actions.md
@@ -36,6 +36,10 @@ SITEURL/!/shopify/variants/{product}?option1=VALUE&option2=VALUE&option3=VALUE
 
 If you want to create a Shopify Address for a customer you can POST to
 
+The address endpoints require an authenticated Statamic user and always act on
+that user's linked Shopify customer (their `shopify_id`). Any `customer_id` sent
+in the request is ignored.
+
 #### Usage
 
 ```bash
@@ -44,7 +48,6 @@ SITEURL/!/shopify/address
 
 | Parameters             | Description   | Required  |
 | -------------------| ------------- | --------- |
-| `customer_id`          | customer_id in Shopify. Defaults to the logged in user's customer_id | N |
 | `first_name`          | Address first name | Y |
 | `last_name`          | Address last name | Y |
 | `company`          | Address company | N |
@@ -80,7 +83,6 @@ SITEURL/!/shopify/address/{id}
 
 | Parameters             | Description   | Required  |
 | -------------------| ------------- | --------- |
-| `customer_id`          | customer_id in Shopify. Defaults to the logged in user's customer_id | N |
 | `first_name`          | Address first name | Y |
 | `last_name`          | Address last name | Y |
 | `company`          | Address company | N |
@@ -108,15 +110,14 @@ SITEURL/!/shopify/address/{id}
 
 If you want to delete a Shopify Address for a customer you can send a DELETE request to
 
+The request must come from an authenticated Statamic user; the address is deleted
+from that user's linked Shopify customer.
+
 #### Usage
 
 ```bash
 SITEURL/!/shopify/address/{id}
 ```
-
-| Parameters             | Description   | Required  |
-| -------------------| ------------- | --------- |
-| `customer_id`          | customer_id in Shopify. Defaults to the logged in user's customer_id | N |
 
 #### Returned Data
 

--- a/docs/content/4.frontend/2.tags.md
+++ b/docs/content/4.frontend/2.tags.md
@@ -207,7 +207,9 @@ Return any Shopify addresses associated with the current logged in user, or the 
 
 ## Customer Address Form
 
-Creates a form that directs to the appropriate endpoint for processing a customer address. 
+Creates a form that directs to the appropriate endpoint for processing a customer address.
+
+The address endpoints require an authenticated Statamic user and always act on that user's linked Shopify customer, so this form only works for logged in users.
 
 #### Usage
 
@@ -216,14 +218,10 @@ Creates a form that directs to the appropriate endpoint for processing a custome
 ```
 
 ```twig
-{{ shopify:address_form customer_id="my_id" }} ... {{ /shopify:address_form }}
-```
-
-```twig
 {{ shopify:address_form address_id="address_id_to_edit" }} ... {{ /shopify:address_form }}
 ```
 
-You can optionally specific `redirect` and `error_redirect` params to be taken to a different page on success or error respectively.
+You can optionally specific `redirect` and `error_redirect` params to be taken to a different page on success or error respectively. Off-site URLs are ignored.
 
 Any errors during processing will be available in the `{{ errors }}` variable. 
 

--- a/docs/content/4.frontend/2.tags.md
+++ b/docs/content/4.frontend/2.tags.md
@@ -179,7 +179,7 @@ Check if a product is in stock or not.
 
 ## Customer
 
-Return any Shopify customer data associated with the current logged in user, or the `customer_id` passed as a parameter.
+Return the Shopify customer data for the current logged in user. If nobody is logged in, `{{ not_found }}` is set.
 
 #### Usage
 
@@ -187,22 +187,14 @@ Return any Shopify customer data associated with the current logged in user, or 
 {{ shopify:customer }} ... {{ /shopify:customer }}
 ```
 
-```twig
-{{ shopify:customer customer_id="my_id" }} ... {{ /shopify:customer }}
-```
-
 ## Customer Addresses
 
-Return any Shopify addresses associated with the current logged in user, or the `customer_id` passed as a parameter.
+Return the Shopify addresses for the current logged in user.
 
 #### Usage
 
 ```twig
 {{ shopify:customer:addresses }} ... {{ /shopify:customer:addresses }}
-```
-
-```twig
-{{ shopify:customer:addresses customer_id="my_id" }} ... {{ /shopify:customer:addresses }}
 ```
 
 ## Customer Address Form
@@ -228,16 +220,12 @@ Any errors during processing will be available in the `{{ errors }}` variable.
 
 ## Customer Orders
 
-Return any Shopify addresses associated with the current logged in user, or the `customer_id` passed as a parameter.
+Return the Shopify orders for the current logged in user.
 
 #### Usage
 
 ```twig
 {{ shopify:customer:orders }} ... {{ /shopify:customer:orders }}
-```
-
-```twig
-{{ shopify:customer:orders customer_id="my_id" }} ... {{ /shopify:customer:orders }}
 ```
 
 This tag also supports pagination:

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -10,7 +10,7 @@ use StatamicRadPack\Shopify\Http\Middleware\VerifyShopifyHeaders;
 Route::name('shopify.')
     ->group(function () {
         Route::prefix('address')
-            ->middleware([HandlePrecognitiveRequests::class])
+            ->middleware(['auth', 'throttle:60,1', HandlePrecognitiveRequests::class])
             ->group(function () {
                 Route::post('/', [AddressController::class, 'create'])
                     ->name('address.create');

--- a/src/Http/Controllers/Actions/AddressController.php
+++ b/src/Http/Controllers/Actions/AddressController.php
@@ -13,18 +13,18 @@ class AddressController extends BaseActionController
 {
     public function create(Requests\CreateOrUpdateAddressRequest $request)
     {
-        $customerId = request()->input('customer_id') ?? User::current()?->get('shopify_id') ?? false;
+        $customerId = User::current()?->get('shopify_id') ?: false;
 
         if (! $customerId) {
-            return $this->withErrors($request, __('No customer_id to associate the address with'));
+            return $this->withErrors($request, __('No Shopify customer is associated with the current user'));
         }
 
         $validatedData = $request->validated();
 
         try {
             $query = <<<'QUERY'
-            mutation customerAddressCreate(\$address: MailingAddressInput!, \$customerId: ID!, \$setAsDefault: Boolean) {
-              customerAddressCreate(address: \$address, customerId: \$customerId, setAsDefault: \$setAsDefault) {
+            mutation customerAddressCreate($address: MailingAddressInput!, $customerId: ID!, $setAsDefault: Boolean) {
+              customerAddressCreate(address: $address, customerId: $customerId, setAsDefault: $setAsDefault) {
                 address {
                   id
                   firstName
@@ -75,10 +75,10 @@ class AddressController extends BaseActionController
 
     public function destroy(Request $request, $id)
     {
-        $customerId = request()->input('customer_id') ?? User::current()?->get('shopify_id') ?? false;
+        $customerId = User::current()?->get('shopify_id') ?: false;
 
         if (! $customerId) {
-            return $this->withErrors($request, __('No customer_id to associate the address with'));
+            return $this->withErrors($request, __('No Shopify customer is associated with the current user'));
         }
 
         try {
@@ -115,18 +115,18 @@ class AddressController extends BaseActionController
 
     public function store(Requests\CreateOrUpdateAddressRequest $request, $id)
     {
-        $customerId = request()->input('customer_id') ?? User::current()?->get('shopify_id') ?? false;
+        $customerId = User::current()?->get('shopify_id') ?: false;
 
         if (! $customerId) {
-            return $this->withErrors($request, __('No customer_id to associate the address with'));
+            return $this->withErrors($request, __('No Shopify customer is associated with the current user'));
         }
 
         $validatedData = $request->validated();
 
         try {
             $query = <<<'QUERY'
-            mutation customerAddressUpdate(\$address: MailingAddressInput!, $addressId: ID!, \$customerId: ID!, \$setAsDefault: Boolean) {
-              customerAddressUpdate(address: \$address, addressId: \$addressId, customerId: \$customerId, setAsDefault: \$setAsDefault) {
+            mutation customerAddressUpdate($address: MailingAddressInput!, $addressId: ID!, $customerId: ID!, $setAsDefault: Boolean) {
+              customerAddressUpdate(address: $address, addressId: $addressId, customerId: $customerId, setAsDefault: $setAsDefault) {
                 address {
                   id
                   firstName

--- a/src/Http/Controllers/Actions/BaseActionController.php
+++ b/src/Http/Controllers/Actions/BaseActionController.php
@@ -18,8 +18,8 @@ class BaseActionController extends Controller
             return response()->json($data);
         }
 
-        return $request->_redirect ?
-            redirect($request->_redirect)->with($data)
+        return ($redirect = $this->safeRedirect($request->_redirect))
+            ? redirect($redirect)->with($data)
             : back()->with($data);
     }
 
@@ -32,8 +32,34 @@ class BaseActionController extends Controller
             ], 422);
         }
 
-        return $request->_error_redirect
-            ? redirect($request->_error_redirect)->withErrors($errorMessage)
+        return ($redirect = $this->safeRedirect($request->_error_redirect))
+            ? redirect($redirect)->withErrors($errorMessage)
             : back()->withErrors($errorMessage);
+    }
+
+    /**
+     * Only allow redirects that stay on this site, so a user-supplied
+     * _redirect / _error_redirect field cannot be used as an open redirect.
+     */
+    private function safeRedirect($redirect): ?string
+    {
+        if (! is_string($redirect) || $redirect === '') {
+            return null;
+        }
+
+        // Normalise backslashes some browsers treat as slashes.
+        $normalised = str_replace('\\', '/', $redirect);
+
+        // Relative path on this site (but not protocol-relative //evil.com).
+        if (str_starts_with($normalised, '/') && ! str_starts_with($normalised, '//')) {
+            return $redirect;
+        }
+
+        // Absolute URL: only if it points back at the current host.
+        if (parse_url($normalised, PHP_URL_HOST) === request()->getHost()) {
+            return $redirect;
+        }
+
+        return null;
     }
 }

--- a/src/Http/Controllers/CP/ImportCollectionsController.php
+++ b/src/Http/Controllers/CP/ImportCollectionsController.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Shopify\Http\Controllers\CP;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Statamic\Http\Controllers\CP\CpController;
 use StatamicRadPack\Shopify\Jobs;
 use StatamicRadPack\Shopify\Traits\FetchCollections;
@@ -11,8 +12,12 @@ class ImportCollectionsController extends CpController
 {
     use FetchCollections;
 
-    public function fetchAll(): JsonResponse
+    public function fetchAll(Request $request): JsonResponse
     {
+        if ($request->user()->cannot('access shopify')) {
+            abort(403);
+        }
+
         collect($this->getManualCollections())
             ->merge($this->getSmartCollections())
             ->each(function ($collectionId) {

--- a/src/Http/Controllers/CP/ImportProductsController.php
+++ b/src/Http/Controllers/CP/ImportProductsController.php
@@ -11,8 +11,12 @@ class ImportProductsController extends CpController
 {
     use FetchAllProducts;
 
-    public function fetchAll(): JsonResponse
+    public function fetchAll(Request $request): JsonResponse
     {
+        if ($request->user()->cannot('access shopify')) {
+            abort(403);
+        }
+
         collect($this->fetchProducts())
             ->each(function ($productId) {
                 $this->callJob($productId);
@@ -25,6 +29,10 @@ class ImportProductsController extends CpController
 
     public function fetchSingleProduct(Request $request): JsonResponse
     {
+        if ($request->user()->cannot('access shopify')) {
+            abort(403);
+        }
+
         $this->callJob((int) $request->get('product'));
 
         return response()->json([

--- a/src/Http/Controllers/CP/ProductsController.php
+++ b/src/Http/Controllers/CP/ProductsController.php
@@ -3,13 +3,18 @@
 namespace StatamicRadPack\Shopify\Http\Controllers\CP;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Statamic\Facades\Entry;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ProductsController extends CpController
 {
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
+        if ($request->user()->cannot('access shopify')) {
+            abort(403);
+        }
+
         $products = Entry::query()
             ->where('collection', config('shopify.collection_handle', 'products'))
             ->get()

--- a/src/Http/Controllers/CP/VariantsController.php
+++ b/src/Http/Controllers/CP/VariantsController.php
@@ -10,8 +10,12 @@ use StatamicRadPack\Shopify\Blueprints\VariantBlueprint;
 
 class VariantsController extends CpController
 {
-    public function fetch($product)
+    public function fetch(Request $request, $product)
     {
+        if ($request->user()->cannot('access shopify')) {
+            abort(403);
+        }
+
         $site = Site::selected()->handle();
 
         return Entry::query()
@@ -31,9 +35,20 @@ class VariantsController extends CpController
 
     public function update(Request $request)
     {
+        if ($request->user()->cannot('access shopify')) {
+            abort(403);
+        }
+
         if (! $request->id) {
             // TODO: Throw error
             return;
+        }
+
+        // Find the entry, and make sure it's actually a variant before we touch it.
+        $variant = Entry::find($request->id);
+
+        if (! $variant || $variant->collectionHandle() !== 'variants') {
+            abort(404);
         }
 
         // Match the values to the blueprint, validate.
@@ -42,8 +57,6 @@ class VariantsController extends CpController
         $fields->validate();
         $values = $fields->process()->values()->toArray();
 
-        // Find and update the entry
-        $variant = Entry::find($request->id);
         $variant->data($values);
         $variant->save();
     }

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -413,32 +413,16 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     }
 
     /**
-     * Get the data associated with the customer, or the current user
+     * Get the Shopify data for the logged in user's linked customer.
      *
      * @return Collection|null
      */
     public function customer()
     {
         $storeParam = $this->params->get('store');
-        $id = $this->params->get('customer_id');
-        $user = false;
 
-        if (! $id) {
-            $user = User::current();
-
-            if (! $user) {
-                return ['not_found' => true];
-            }
-        }
-
-        if (! $user) {
-            $user = User::query()
-                ->where('shopify_id', $id)
-                ->first();
-
-            if (! $user) {
-                return ['not_found' => true];
-            }
+        if (! $user = User::current()) {
+            return ['not_found' => true];
         }
 
         [$customerId, $graphql] = $this->resolveCustomerGraphql($user, $storeParam);
@@ -458,16 +442,18 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
 
         $response = $graphql->query(['query' => $query]);
 
-        if ($data = Arr::get($response->getDecodedBody() ?? [], 'data.customer', [])) {
+        $data = [];
+
+        if ($customer = Arr::get($response->getDecodedBody() ?? [], 'data.customer', [])) {
             $data = [
-                'email' => $data['email'],
-                'name' => $data['displayName'],
-                'last_order_id' => Arr::get($data, 'lastOrder.id'),
-                'note' => $data['note'],
+                'email' => $customer['email'],
+                'name' => $customer['displayName'],
+                'last_order_id' => Arr::get($customer, 'lastOrder.id'),
+                'note' => $customer['note'],
             ];
         }
 
-        return array_merge($data, $user?->data()->all() ?? []);
+        return array_merge($data, $user->data()->all());
     }
 
     /**
@@ -478,25 +464,9 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     public function customerAddresses()
     {
         $storeParam = $this->params->get('store');
-        $id = $this->params->get('customer_id');
-        $user = false;
 
-        if (! $id) {
-            $user = User::current();
-
-            if (! $user) {
-                return ['addresses' => [], 'addresses_count' => 0];
-            }
-        }
-
-        if (! $user) {
-            $user = User::query()
-                ->where('shopify_id', $id)
-                ->first();
-
-            if (! $user) {
-                return ['addresses' => [], 'addresses_count' => 0];
-            }
+        if (! $user = User::current()) {
+            return ['addresses' => [], 'addresses_count' => 0];
         }
 
         [$customerId, $graphql] = $this->resolveCustomerGraphql($user, $storeParam);
@@ -546,25 +516,9 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     public function customerOrders()
     {
         $storeParam = $this->params->get('store');
-        $id = $this->params->get('customer_id');
-        $user = false;
 
-        if (! $id) {
-            $user = User::current();
-
-            if (! $user) {
-                return ['orders' => [], 'orders_count' => 0];
-            }
-        }
-
-        if (! $user) {
-            $user = User::query()
-                ->where('shopify_id', $id)
-                ->first();
-
-            if (! $user) {
-                return ['orders' => [], 'orders_count' => 0];
-            }
+        if (! $user = User::current()) {
+            return ['orders' => [], 'orders_count' => 0];
         }
 
         $status = '';

--- a/src/Tags/Shopify.php
+++ b/src/Tags/Shopify.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Shopify\Tags;
 
+use Illuminate\Support\Collection;
 use Shopify\Clients\Graphql;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Entry;
@@ -198,7 +199,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     /**
      * Return the collection back so we can use it on the front end.
      *
-     * @return \Illuminate\Support\Collection|null
+     * @return Collection|null
      */
     public function variants()
     {
@@ -369,7 +370,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     /**
      * Get the data associated with the customer, or the current user
      *
-     * @return \Illuminate\Support\Collection|null
+     * @return Collection|null
      */
     public function addressForm()
     {
@@ -380,6 +381,9 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
             $endpoint = route('statamic.shopify.address.store', ['id' => $id]);
         }
 
+        // customer_id is still accepted as a param so it isn't rendered as a form
+        // attribute, but it is deliberately ignored - the address endpoints scope
+        // to the logged in user and no longer trust a client-supplied id.
         $knownParams = ['redirect', 'error_redirect', 'address_id', 'customer_id'];
 
         $html = $this->formOpen($endpoint, 'POST', $knownParams);
@@ -395,22 +399,10 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
         }
 
         if (! $this->parser) {
-            return array_merge([
+            return [
                 'attrs' => $this->formAttrs($endpoint, 'post', $knownParams),
                 'params' => $this->formMetaPrefix($this->formParams('post', $params)),
-            ], $data);
-        }
-
-        $id = $this->params->get('customer_id');
-
-        if (! $id) {
-            if ($user = User::current()) {
-                $id = $user->get('shopify_id');
-            }
-        }
-
-        if ($id) {
-            $html .= '<input type="hidden" name="customer_id" value="'.$id.'" />';
+            ];
         }
 
         $html .= $this->formMetaFields($params);
@@ -423,7 +415,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     /**
      * Get the data associated with the customer, or the current user
      *
-     * @return \Illuminate\Support\Collection|null
+     * @return Collection|null
      */
     public function customer()
     {
@@ -481,7 +473,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     /**
      * Get the customer addresses
      *
-     * @return \Illuminate\Support\Collection|null
+     * @return Collection|null
      */
     public function customerAddresses()
     {
@@ -549,7 +541,7 @@ window.shopifyConfig = { url: '".(config('shopify.storefront_url') ?? config('sh
     /**
      * Get the customer orders
      *
-     * @return \Illuminate\Support\Collection|null
+     * @return Collection|null
      */
     public function customerOrders()
     {

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -7,10 +7,18 @@ use PHPUnit\Framework\Attributes\Test;
 use Shopify\Clients\Graphql;
 use Shopify\Clients\HttpResponse;
 use Statamic\Facades;
+use Statamic\Facades\User;
 use StatamicRadPack\Shopify\Tests\TestCase;
 
 class ActionsTest extends TestCase
 {
+    private function actingAsCustomer(int $shopifyId = 1)
+    {
+        $user = tap(User::make()->email('customer@example.com')->set('shopify_id', $shopifyId))->save();
+
+        return $this->actingAs($user);
+    }
+
     #[Test]
     public function gets_correct_data_from_action_url()
     {
@@ -63,8 +71,45 @@ class ActionsTest extends TestCase
     }
 
     #[Test]
+    public function address_endpoints_require_authentication()
+    {
+        $this->postJson('/!/shopify/address', ['firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g'])
+            ->assertStatus(401);
+
+        $this->postJson('/!/shopify/address/1', ['firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g'])
+            ->assertStatus(401);
+
+        $this->postJson('/!/shopify/address/1', ['_method' => 'delete'])
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function address_is_scoped_to_the_logged_in_user_not_a_supplied_customer_id()
+    {
+        $captured = null;
+
+        $this->mock(Graphql::class, function (MockInterface $mock) use (&$captured) {
+            $mock
+                ->shouldReceive('query')
+                ->andReturnUsing(function ($args) use (&$captured) {
+                    $captured = $args;
+
+                    return new HttpResponse(status: 200, body: '{"data":{"customerAddressCreate":{"address":{"id":"gid://shopify/MailingAddress/1"},"userErrors":[]}}}');
+                });
+        });
+
+        $this->actingAsCustomer(555)
+            ->postJson('/!/shopify/address', ['customer_id' => 999, 'firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g'])
+            ->assertStatus(200);
+
+        $this->assertSame('gid://shopify/Customer/555', $captured['variables']['customerId']);
+    }
+
+    #[Test]
     public function creates_an_address()
     {
+        $this->actingAsCustomer();
+
         $this->mock(Graphql::class, function (MockInterface $mock) {
             $mock
                 ->shouldReceive('query')
@@ -97,16 +142,15 @@ class ActionsTest extends TestCase
         $response = $this->postJson('/!/shopify/address', []);
         $response->assertStatus(422);
 
-        $response = $this->postJson('/!/shopify/address', ['customer_id' => 1]);
-        $response->assertStatus(422);
-
-        $response = $this->postJson('/!/shopify/address', ['customer_id' => 1, 'firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g']);
+        $response = $this->postJson('/!/shopify/address', ['firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g']);
         $response->assertStatus(200);
     }
 
     #[Test]
     public function updates_an_address()
     {
+        $this->actingAsCustomer();
+
         $this->mock(Graphql::class, function (MockInterface $mock) {
             $mock
                 ->shouldReceive('query')
@@ -139,16 +183,15 @@ class ActionsTest extends TestCase
         $response = $this->postJson('/!/shopify/address/1', []);
         $response->assertStatus(422);
 
-        $response = $this->postJson('/!/shopify/address/1', ['customer_id' => 1]);
-        $response->assertStatus(422);
-
-        $response = $this->postJson('/!/shopify/address/1', ['customer_id' => 1, 'firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g']);
+        $response = $this->postJson('/!/shopify/address/1', ['firstName' => 'a', 'lastName' => 'b', 'address1' => 'c', 'city' => 'd', 'province' => 'e', 'zip' => 'f', 'country' => 'g']);
         $response->assertStatus(200);
     }
 
     #[Test]
     public function deletes_an_address()
     {
+        $this->actingAsCustomer();
+
         $this->mock(Graphql::class, function (MockInterface $mock) {
             $mock
                 ->shouldReceive('query')
@@ -166,9 +209,6 @@ class ActionsTest extends TestCase
         });
 
         $response = $this->postJson('/!/shopify/address/1', ['_method' => 'delete']);
-        $response->assertStatus(422);
-
-        $response = $this->postJson('/!/shopify/address/1', ['_method' => 'delete', 'customer_id' => 1]);
         $response->assertStatus(200);
     }
 
@@ -176,6 +216,7 @@ class ActionsTest extends TestCase
     public function can_use_precognition_when_creating_an_address()
     {
         $response = $this
+            ->actingAsCustomer()
             ->withPrecognition()
             ->postJson('/!/shopify/address', []);
 
@@ -187,6 +228,7 @@ class ActionsTest extends TestCase
     public function can_use_precognition_when_updating_an_address()
     {
         $response = $this
+            ->actingAsCustomer()
             ->withPrecognition()
             ->postJson('/!/shopify/address/1', []);
 

--- a/tests/Unit/CpImportControllersTest.php
+++ b/tests/Unit/CpImportControllersTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace StatamicRadPack\Shopify\Tests\Unit;
+
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Shopify\Clients\Graphql;
+use Shopify\Clients\HttpResponse;
+use Statamic\Facades\User;
+use StatamicRadPack\Shopify\Tests\TestCase;
+
+class CpImportControllersTest extends TestCase
+{
+    private function actingAsSuperUser()
+    {
+        return $this->actingAs(User::make()->email('admin@example.com')->makeSuper()->save());
+    }
+
+    private function actingAsPlainUser()
+    {
+        return $this->actingAs(tap(User::make()->email('nobody@example.com'))->save());
+    }
+
+    public static function guardedEndpoints(): array
+    {
+        return [
+            'import all products' => ['shopify.products.fetchAll'],
+            'import single product' => ['shopify.products.fetch'],
+            'import all collections' => ['shopify.collections.fetchAll'],
+            'list products' => ['shopify.products'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('guardedEndpoints')]
+    public function endpoints_require_the_access_shopify_permission(string $route)
+    {
+        $this->actingAsPlainUser()
+            ->getJson(cp_route($route))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function a_permitted_user_can_trigger_a_single_product_import()
+    {
+        $this->mock(Graphql::class, function (MockInterface $mock) {
+            $mock->shouldReceive('query')->andReturn(new HttpResponse(status: 200, body: '{"data":{}}'));
+        });
+
+        $this->actingAsSuperUser()
+            ->getJson(cp_route('shopify.products.fetch', ['product' => 1]))
+            ->assertOk()
+            ->assertJsonPath('message', 'Product import has been queued.');
+    }
+}

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -387,7 +387,8 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2025-04' };
 
         $this->assertEquals('<form method="POST" action="http://localhost/!/shopify/address/1"><input type="hidden" name="_token" value="">Some content</form>', str_replace(' autocomplete="off"', '', $this->tag('{{ shopify:address_form address_id="1" }}Some content{{ /shopify:address_form }}')));
 
-        $this->assertEquals('<form method="POST" action="http://localhost/!/shopify/address"><input type="hidden" name="_token" value=""><input type="hidden" name="customer_id" value="1" />Some content</form>', str_replace(' autocomplete="off"', '', $this->tag('{{ shopify:address_form customer_id="1"  }}Some content{{ /shopify:address_form }}')));
+        // customer_id is accepted but ignored - it must not leak into the form as a field or attribute.
+        $this->assertEquals('<form method="POST" action="http://localhost/!/shopify/address"><input type="hidden" name="_token" value="">Some content</form>', str_replace(' autocomplete="off"', '', $this->tag('{{ shopify:address_form customer_id="1"  }}Some content{{ /shopify:address_form }}')));
     }
 
     #[Test]

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -419,11 +419,13 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2025-04' };
             ])
         )->save();
 
-        $this->assertEquals('706405506930370000 - bob@biller.com', $this->tag('{{ shopify:customer customer_id="706405506930370000" }}{{ shopify_id }} - {{ email }}{{ /shopify:customer }}'));
-
-        $this->assertEquals('yes', $this->tag('{{ shopify:customer customer_id="706405506930370001" }}{{ if not_found }}yes{{ /if }}{{ /shopify:customer }}'));
+        // No logged in user: nothing to return, even with a customer_id param.
+        $this->assertEquals('yes', $this->tag('{{ shopify:customer customer_id="706405506930370000" }}{{ if not_found }}yes{{ /if }}{{ /shopify:customer }}'));
 
         $this->actingAs($user);
+
+        // customer_id is ignored - the tag always resolves to the logged in user.
+        $this->assertEquals('706405506930370000 - bob@biller.com', $this->tag('{{ shopify:customer customer_id="999" }}{{ shopify_id }} - {{ email }}{{ /shopify:customer }}'));
         $this->assertEquals('706405506930370000 - bob@biller.com', $this->tag('{{ shopify:customer }}{{ shopify_id }} - {{ email }}{{ /shopify:customer }}'));
     }
 
@@ -473,11 +475,13 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2025-04' };
             ])
         )->save();
 
-        $this->assertEquals('207119551 - Chestnut Street 92', $this->tag('{{ shopify:customer:addresses customer_id="706405506930370000" }}{{ addresses }}{{ id }} - {{ address1 }}{{ /addresses }}{{ /shopify:customer:addresses }}'));
-
-        $this->assertEquals('0', $this->tag('{{ shopify:customer:addresses customer_id="706405506930370001" }}{{ addresses_count }}{{ /shopify:customer:addresses }}'));
+        // No logged in user: nothing to return, even with a customer_id param.
+        $this->assertEquals('0', $this->tag('{{ shopify:customer:addresses customer_id="706405506930370000" }}{{ addresses_count }}{{ /shopify:customer:addresses }}'));
 
         $this->actingAs($user);
+
+        // customer_id is ignored - addresses are always for the logged in user.
+        $this->assertEquals('207119551 - Chestnut Street 92', $this->tag('{{ shopify:customer:addresses customer_id="999" }}{{ addresses }}{{ id }} - {{ address1 }}{{ /addresses }}{{ /shopify:customer:addresses }}'));
         $this->assertEquals('207119551 - Chestnut Street 92', $this->tag('{{ shopify:customer:addresses }}{{ addresses }}{{ id }} - {{ address1 }}{{ /addresses }}{{ /shopify:customer:addresses }}'));
     }
 
@@ -1507,11 +1511,13 @@ window.shopifyConfig = { url: 'abcd', token: '1234', apiVersion: '2025-04' };
             ])
         )->save();
 
-        $this->assertEquals('450789469', $this->tag('{{ shopify:customer:orders customer_id="706405506930370000" }}{{ orders }}{{ id }}{{ /orders }}{{ /shopify:customer:orders }}'));
-
-        $this->assertEquals('0', $this->tag('{{ shopify:customer:orders customer_id="706405506930370001" }}{{ orders_count }}{{ /shopify:customer:orders }}'));
+        // No logged in user: nothing to return, even with a customer_id param.
+        $this->assertEquals('0', $this->tag('{{ shopify:customer:orders customer_id="706405506930370000" }}{{ orders_count }}{{ /shopify:customer:orders }}'));
 
         $this->actingAs($user);
+
+        // customer_id is ignored - orders are always for the logged in user.
+        $this->assertEquals('450789469', $this->tag('{{ shopify:customer:orders customer_id="999" }}{{ orders }}{{ id }}{{ /orders }}{{ /shopify:customer:orders }}'));
         $this->assertEquals('450789469', $this->tag('{{ shopify:customer:orders }}{{ orders }}{{ id }}{{ /orders }}{{ /shopify:customer:orders }}'));
 
         $this->assertEquals('450789469', $this->tag('{{ shopify:customer:orders paginate="1" }}{{ orders }}{{ id }}{{ /orders }}{{ /shopify:customer:orders }}'));

--- a/tests/Unit/VariantsControllerTest.php
+++ b/tests/Unit/VariantsControllerTest.php
@@ -117,4 +117,35 @@ class VariantsControllerTest extends TestCase
         $response->assertJsonPath('0.price', '12.00');
         $response->assertJsonPath('0.sku', 'DE-1');
     }
+
+    #[Test]
+    public function fetch_and_update_require_the_access_shopify_permission()
+    {
+        $variant = $this->makeVariant('variant-en', ['title' => 'Origin Title', 'price' => '9.99', 'sku' => 'ORIGIN-1']);
+
+        $user = tap(User::make()->email('nobody@example.com'))->save();
+
+        $this->actingAs($user)
+            ->getJson(cp_route('shopify.variants.index', 'test-product'))
+            ->assertForbidden();
+
+        $this->actingAs($user)
+            ->patchJson(cp_route('shopify.variants.edit', $variant->id()), ['title' => 'Hacked'])
+            ->assertForbidden();
+
+        $this->assertSame('Origin Title', $variant->fresh()->get('title'));
+    }
+
+    #[Test]
+    public function update_refuses_to_touch_entries_outside_the_variants_collection()
+    {
+        Facades\Collection::make('pages')->save();
+        $page = tap(Facades\Entry::make()->collection('pages')->slug('about')->data(['title' => 'About us']))->save();
+
+        $this->actingAsSuperUser()
+            ->patchJson(cp_route('shopify.variants.edit', $page->id()), ['title' => 'Overwritten'])
+            ->assertNotFound();
+
+        $this->assertSame('About us', $page->fresh()->get('title'));
+    }
 }


### PR DESCRIPTION
Remove customer_id from any customer/address tags - default only to the logged in user.
Add throttling and auth to the customer address update end points
Ensure CP routes can only be accessed with correct permissions 